### PR TITLE
chore: update mmCIF dictionary to 5.413

### DIFF
--- a/sloth/mmcif/schemas/mmcif_pdbx_v50.dic
+++ b/sloth/mmcif/schemas/mmcif_pdbx_v50.dic
@@ -9,7 +9,7 @@ _datablock.description
 #
 _dictionary.title         mmcif_pdbx.dic
 _dictionary.datablock_id  mmcif_pdbx.dic
-_dictionary.version       5.404
+_dictionary.version       5.413
 #
 loop_
 _dictionary_history.version
@@ -3304,6 +3304,90 @@ Changes (ep):
     _pdbx_chem_comp_pcm.type and _pdbx_modification_feature.type
 ;
   
+5.405  2025-08-25  
+;
+Changes (ep):
+  + Update enumeration for _chem_comp.pdbx_comp_type
+  + Add 'Modify metal description' to _pdbx_chem_comp_audit.action_type
+    eumeration
+  + Add "EMS Formvar Carbon" to _em_sample_support.grid_type
+  + Add Velox, EPU-D, CrystFEL, TOMOMAN to _em_software.name enumeration
+  + Add Laueprocess to _software.name enumeration
+;
+  
+5.406  2025-09-02  
+;
+Changes (ep):
+  + Add MX3 and "BL09U MX-ES" to _diffrn_source.pdbx_synchrotron_beamline
+    enumeration
+  + Add "AUSTRALIAN SYNCHROTRON BEAMLINE MX3" and
+    "NanoTerasu BEAMLINE BL09U MX-ES" to
+    _diffrn_source.type enumeration
+  + Add NanoTerasu to _diffrn_source.pdbx_synchrotron_site
+;
+  
+5.407  2025-11-04  
+;
+Changes (ep):
+  + Add MemBrain, AreTomo, DataSMART, CryoSMART to _em_software.name enumeration
+  + Add "TFS FALCON C (2k x 2k) to _em_image_recording.film_or_detector_model
+  + Add 'DECTRIS PILATUS 1M' detector to _diffrn_detector.type
+  + Add ANTcryo ANTA grids to _em_sample_support.grid_type
+  + Add SHUIUMU TOTEM microscopes to _em_imgaing.microscope_model enumeration
+  + Add AutoPD to _software.name enumeration
+  + Add _pdbx_related_exp_data_set.db_source
+;
+  
+5.408  2025-11-26  
+;
+Changes (ep):
+  + Correct SHUIUMU TOTEM microscope names in _em_imgaing.microscope_model enumeration
+  + Correct symmetry_operation regular expression to include lower case z
+  + Adjust advisory limits for _reflns_shell.pdbx_Rrim_I_all
+;
+  
+5.409  2025-12-15  
+;
+Changes (ep):
+  + Add new DECTRIS detectors to _diffrn_detector.type enumeraton"
+  + Add ModelAngelo to _em_software.name enumeration
+  + Add "ALBA BEAMLINE XAIRA" to _diffrn_source.type enumeration
+;
+  
+5.410  2026-01-10  
+;
+Changes (ep):
+  + Remove upper limit for reflns.pdbx_Rrim_I_all
+  + Remove pdbx_item_type from _pdbx_database_related.db_id as item_type already includes.
+  + Add GisSPA to _em_software.name enumeration
+  + Include chemical component metallo extension
+;
+  
+5.411  2026-03-16  
+;
+Changes (ep):
+  + For deposition, add a pdbx_wavelength_list data type
+  + Extend enumeration for _em_sample_support.grid_type to include
+    "Quantifoil R1/1", "Quantifoil R1/2", "Quantifoil R3/5", "Quantifoil R1.2/20"
+  + Add SmartScope to _em_software.name enumeration
+;
+  
+5.412  2026-03-25  
+;
+  + Change datatype nanometer(s) to nanometre(s) to be consistent throughout
+  + _diffrn_source.type add "HEPS BEAMLINE ID02U1A",
+    _diffrn_source.pdbx_synchrotron_site add "HEPS",
+    _diffrn_source.pdbx_synchrotron_beamlin add "ID02U1A"
+  + Extend enumeration of pdbx_related_exp_data_set.db_source
+  + Add "raw EM image data" to _pdbx_related_exp_data_set.data_set_type and remove EMPIAR
+;
+  
+5.413  2026-04-06  
+;
+  + Extend description of _pdbx_struct_assembly_prop
+  + Add "metal coordination" to enumeration for _pdbx_data_processing_status.task_name
+;
+  
 #
 loop_
 _sub_category.id
@@ -3639,12 +3723,13 @@ point_group_helical       char   "[CD][1-9][0-9]*"  "Point group symmetry for he
 boolean                   char   YES|NO  "Boolean type"  
 author                    char   "(([A-Za-z0-9_]+(( |-|'|\. )[A-Za-z0-9_]+)*( Jr.| III)?, [A-Za-z0-9_]\.(-?[A-Za-z0-9_]+\.)*)|(Seattle Structural Genomics Center for Infectious Disease.*)|(Structural Genomics Consortium.*)|(QCRG Structural Biology Consortium.*)|(Center for Structural Genomics of Infectious Diseases.*)|(Center for Structural Biology of Infectious Diseases.*)|(Center for Structures of Membrane Proteins.*))"  "Author name in PDB format: Taylor, C.A."  
 orcid_id                  char   "[0-9]{4}-[0-9]{4}-[0-9]{4}-([0-9]{3}X|[0-9]{4})"  "ORCID pattern - dddd-dddd-dddd-dddd|dddX"  
-symmetry_operation        char   "[-+0-9XxYyZ/ ]+,[-+0-9XxYyZ/ ]+,[-+0-9XxYyZ/ ]+"  "Allowed characters for use in symmetry operation such as 1/2-x,y,1/2-z"  
+symmetry_operation        char   "[-+0-9XxYyZz/ ]+,[-+0-9XxYyZz/ ]+,[-+0-9XxYyZz/ ]+"  "Allowed characters for use in symmetry operation such as 1/2-x,y,1/2-z"  
 sequence_dep              char   "[a-zA-Z0-9\t \r\n\v\f\(\)]+$"  "Deposition specific one letter code"  
 date_dep                  char   ([1-9][0-9](([02468][048])|([13579][26]))-02-29)|[1-9][0-9][0-9][0-9]-((((0[1-9])|(1[0-2]))-((0[1-9])|(1[0-9])|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30))))  "Deposition specific date with better checking"  
 citation_doi              char   10\..*  "Citation DOI specification."  
 exp_data_doi              char   10\.[0-9]{4,9}/[-._;()/:A-Za-z0-9]+  "Experimental dataset DOI"  
 deposition_email          uchar  "[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9.-]+"  "code item types/single words  (case insensitive) ..."  
+pdbx_wavelength_list      char   "((([0-9]+(\.[0-9]*)?)|(\.[0-9]+))|(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)) *- *(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)) *) *(, *((([0-9]+(\.[0-9]*)?)|(\.[0-9]+))|(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)) *- *(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)) *) *)*"  "Comma separated list of wavelengths and ranges"  
 entity_id_list            uchar  "[0-9A-Za-z]+(,[0-9A-Za-z]+)*"  "comma separated alphanumeric codes (no spaces)  ..."  
 int_list                  uchar  "[1-9][0-9]*(,[1-9][0-9]*)*"  "comma separated list of positive integers (no spaces)  ..."  
 uniprot_ptm_id            char   PTM-[0-9]{4}  "UniProt PTM List Accession ID Pattern - PTM-XXXX"  
@@ -3657,7 +3742,6 @@ centimetres                     "centimetres (metres * 10^( -2)^)"
 millimetres                     "millimetres (metres * 10^( -3)^)"  
 micrometres                     "micrometres (metres * 10^( -6)^)"  
 nanometres                      "nanometres  (metres * 10^( -9)^)"  
-nanometers                      "nanometers  (metres * 10^( -9)^)"  
 angstroms                       "angstroms   (metres * 10^(-10)^)"  
 picometres                      "picometres  (metres * 10^(-12)^)"  
 femtometres                     "femtometres (metres * 10^(-15)^)"  
@@ -3707,7 +3791,7 @@ milliliters                     "liter / 1000"
 milligrams                      "grams / 1000"  
 megadaltons                     megadaltons  
 kilodaltons                     kilodaltons  
-kilodaltons/nanometer           kilodaltons/nanometer  
+kilodaltons/nanometre           kilodaltons/nanometre  
 microns_squared                 "micrometres squared (metres * 10^( -6)^)^2^"  
 microns                         "micrometres  (metres * 10^( -6)^)"  
 electrons_angstrom_squared      "electrons square angstrom"  
@@ -3850,13 +3934,14 @@ _pdbx_dictionary_component.datablock_id
 _pdbx_dictionary_component.dictionary_component_id
 _pdbx_dictionary_component.title
 _pdbx_dictionary_component.version
-mmcif_pdbx-base.dic                     mmcif_pdbx-base.dic                     "mmCIF/PDBx base dictionary"                   0.40   
-mmcif_xfel_extensions-v3.dic            mmcif_xfel_extensions-v3.dic            "PDBx/mmCIF XFELDictionary License Extension"  0.0.2  
-mmcif_pdbx_audit_support-extension.dic  mmcif_pdbx_audit_support-extension.dic  "mmCIF/PDBx Audit support extension"           0.24   
-mmcif_pdbx_sifts.dic                    mmcif_pdbx_sifts.dic                    "PDBx/mmCIF Dictionary Sifts Extension"        0.0.2  
-mmcif_pdbx_license.dic                  mmcif_pdbx_license.dic                  "PDBx/mmCIF Dictionary License Extension"      0.0.1  
-initial-model-extension.dic             initial-model-extension.dic             "PDBx/mmCIF Initial model extension"           0.10   
-ptm-extension.dic                       ptm-extension.dic                       "PDBx/mmCIF PTM extension"                     0.11   
+mmcif_pdbx-base.dic                     mmcif_pdbx-base.dic                     "mmCIF/PDBx base dictionary"                                 0.49   
+mmcif_xfel_extensions-v3.dic            mmcif_xfel_extensions-v3.dic            "PDBx/mmCIF XFELDictionary License Extension"                0.0.2  
+mmcif_pdbx_audit_support-extension.dic  mmcif_pdbx_audit_support-extension.dic  "mmCIF/PDBx Audit support extension"                         0.24   
+mmcif_pdbx_sifts.dic                    mmcif_pdbx_sifts.dic                    "PDBx/mmCIF Dictionary Sifts Extension"                      0.0.2  
+mmcif_pdbx_license.dic                  mmcif_pdbx_license.dic                  "PDBx/mmCIF Dictionary License Extension"                    0.0.1  
+initial-model-extension.dic             initial-model-extension.dic             "PDBx/mmCIF Initial model extension"                         0.10   
+ptm-extension.dic                       ptm-extension.dic                       "PDBx/mmCIF PTM extension"                                   0.13   
+chem_comp-metallo-extension.dic         chem_comp-metallo-extension.dic         "PDBx/mmCIF extension to support metalloprotein annotation"  0.13   
 #
 loop_
 _pdbx_dictionary_component_history.dictionary_component_id
@@ -4200,6 +4285,94 @@ Changes (ep):
   + Add HexAuFoil to _em_sample_support.grid_type enumeration
   + Add "PSI JUNGFRAU 9M" and "PSI JUNGFRAU 10M" detectors to
     _diffrn_detector.type
+;
+  
+mmcif_pdbx-base.dic                     0.41   2025-08-25  
+;
+Changes (ab/ep):
+  + Update enumeration for _chem_comp.pdbx_comp_type
+  + Add 'Modify metal description' to _pdbx_chem_comp_audit.action_type
+    eumeration
+  + Add chem-comp_metallo-extension to dictionary
+  + Add "EMS Formvar Carbon" to _em_sample_support.grid_type
+  + Add Velox, EPU-D, CrystFEL, TOMOMAN to _em_software.name enumeration
+  + Add Laueprocess to _software.name enumeration
+;
+  
+mmcif_pdbx-base.dic                     0.42   2025-09-02  
+;
+Changes (ep):
+  + Add MX3 and "BL09U MX-ES" to _diffrn_source.pdbx_synchrotron_beamline
+    enumeration
+  + Add "AUSTRALIAN SYNCHROTRON BEAMLINE MX3" and
+    "NanoTerasu BEAMLINE BL09U MX-ES" to
+    _diffrn_source.type enumeration
+  + Add NanoTerasu to _diffrn_source.pdbx_synchrotron_site
+;
+  
+mmcif_pdbx-base.dic                     0.43   2025-11-05  
+;
+Changes (ep):
+  + Add MemBrain, AreTomo, DataSMART, CryoSMART to _em_software.name enumeration
+  + Add "TFS FALCON C (2k x 2k) to _em_image_recording.film_or_detector_model
+  + Add 'DECTRIS PILATUS 1M' detector to _diffrn_detector.type
+  + Add ANTcryo ANTA grids to _em_sample_support.grid_type
+  + Add SHUIUMU TOTEM microscopes to _em_imgaing.microscope_model enumeration
+  + Add AutoPD to _software.name enumeration
+  + Add _pdbx_related_exp_data_set.db_source
+;
+  
+mmcif_pdbx-base.dic                     0.44   2025-11-26  
+;
+Changes (ep):
+  + Correct SHUIUMU TOTEM microscope names in _em_imgaing.microscope_model enumeration
+  + Adjust advisory limits for _reflns_shell.pdbx_Rrim_I_all
+;
+  
+mmcif_pdbx-base.dic                     0.45   2025-12-15  
+;
+Changes (ep):
+  + Add new DECTRIS detectors to _diffrn_detector.type enumeraton"
+  + Add ModelAngelo to _em_software.name enumeration
+  + Add "ALBA BEAMLINE XAIRA" to _diffrn_source.type enumeration
+;
+  
+mmcif_pdbx-base.dic                     0.46   2026-01-20  
+;
+Changes (ep):
+  + Remove upper limit for reflns.pdbx_Rrim_I_all
+  + Remove pdbx_item_type from _pdbx_database_related.db_id as item_type already includes.
+  + Add GisSPA to _em_software.name enumeration
+  + Adjust advisory limits for _reflns_shell.pdbx_Rrim_I_all
+  + For _software.name DIMPLE add utilization information
+;
+  
+mmcif_pdbx-base.dic                     0.47   2026-03-15  
+;
+Changes (ep):
+  + Extend enumeration for _em_sample_support.grid_type to include
+    "Quantifoil R1/1", "Quantifoil R1/2", "Quantifoil R3/5", "Quantifoil R1.2/20"
+  + Add SmartScope to _em_software.name enumeration
+  + Add various MicroED processing software to _software.name enumeration
+  + For deposition, add a pdbx_wavelength_list data type
+;
+  
+mmcif_pdbx-base.dic                     0.48   2026-03-25  
+;
+Changes (ep/CV-GPhL):
+  + Change datatype nanometer(s) to nanometre(s) to be consistent throughout
+  + _diffrn_source.type add "HEPS BEAMLINE ID02U1A",
+    _diffrn_source.pdbx_synchrotron_site add "HEPS",
+    _diffrn_source.pdbx_synchrotron_beamlin add "ID02U1A"
+  + Extend enumeration of pdbx_related_exp_data_set.db_source
+  + Add "raw EM image data" to _pdbx_related_exp_data_set.data_set_type and remove EMPIAR
+;
+  
+mmcif_pdbx-base.dic                     0.49   2026-04-06  
+;
+Changes (ep/CV-GPhL):
+  + Extend description of _pdbx_struct_assembly_prop
+  + Add "metal coordination" to enumeration for _pdbx_data_processing_status.task_name
 ;
   
 mmcif_xfel_extensions-v3.dic            0.0.1  2023-05-31  
@@ -4632,9 +4805,158 @@ ptm-extension.dic                       0.11   2024-06-01
   Changes (dh/ep)
   + added "N6-benzoyllysine", "N6-isonicotinyllysine",
     and "N6-methacryllysine" 
-    type to enumeration list for
+    types to enumeration list for
       _pdbx_chem_comp_pcm.type
       _pdbx_modification_feature.type
+;
+  
+ptm-extension.dic                       0.12   2025-08-25  
+;
+  Changes (ab/ep)
+  + added "Metal coordination" type to
+    enumeration for:
+      _pdbx_chem_comp_pcm.type
+      _pdbx_modification_feature.type
+;
+  
+ptm-extension.dic                       0.13   2026-03-16  
+;
+  Changes (ep)
+  + Add CMPylation to _pdbx_chem_comp_pcm.type and _pdbx_modification_feature.type enumerations
+;
+  
+chem_comp-metallo-extension.dic         0.1    2025-01-09  
+;  
+  Changes (ep/ab)
+  + Initial version
+;
+  
+chem_comp-metallo-extension.dic         0.2    2025-01-14  
+;  
+  Changes (ep/ab)
+  + Example updates to pdbx_chem_comp_precursor_identifier and
+    pdbx_chem_comp_precursor_descriptor
+  + Descriptions update for pdbx_chem_comp_precursor_identifier and
+    pdbx_chem_comp_precursor_descriptor
+;
+  
+chem_comp-metallo-extension.dic         0.3    2025-02-27  
+;  
+  Changes (ep/ab)
+  + Add provenance and id attributes to _pdbx_chem_comp_atom_feature, remove validated and validation_software
+  + Add _pdbx_nonpoly_atom_feature
+  + Remove atom_id and instance_id from _pdbx_nonpoly_feature, add label_asym_id
+  + Add category _pdbx_nonpoly_atom_feature_evidence
+;
+  
+chem_comp-metallo-extension.dic         0.4    2025-04-06  
+;  
+  Changes (ep/ab)
+  + Add _pdbx_nonpoly_feature_evidence category
+  + Add enumeration for _pdbx_nonpoly_atom_feature_evidence.type
+  + Add _pdbx_non_poly_atom_feature.type_interpretations
+  + Add enumeration for _pdbx_chem_comp_precursor_descriptor.source
+  + Add _pdbx_nonpoly_atom_feature.assessment.  Change type to uline
+;
+  
+chem_comp-metallo-extension.dic         0.5    2025-04-22  
+;  
+  Changes (ep/cs/ab)
+  + Correct enumeration for _pdbx_chem_comp_precursor_set.class
+  + Change enumeration for _pdbx_nonpoly_atom_feature.assessment to 'Expected',
+    'Unexpected'
+  + Update description of _pdbx_chem_comp_precursor.precursor_comp_id
+  + Update enumeration for _pdbx_chem_comp_precursor_descriptor.source, and
+    _pdbx_chem_comp_precursor_identifier.source
+  + Remove _pdbx_nonpoly_atom_feature.type_interpretation
+;
+  
+chem_comp-metallo-extension.dic         0.6    2025-05-05  
+;  
+  Changes (ab)
+  + Update enumeration for _pdbx_chem_comp_atom_feature.provenance
+;
+  
+chem_comp-metallo-extension.dic         0.7    2025-05-19  
+;  
+  Changes (ab)
+  + Update example for _pdbx_chem_comp_atom_feature
+  + Add "No reference" to enumeration for _pdbx_nonpoly_atom_feature.assessment
+  + Update example for _pdbx_nonpoly_atom_feature
+  + Change metalCoord to MetalCoord in to _pdbx_nonpoly_atom_feature.provenance and
+    _pdbx_chem_comp_atom_feature.provenance enumerations
+  + Change _pdbx_chem_comp_precursor_set.details to be non-mandatory
+;
+  
+chem_comp-metallo-extension.dic         0.8    2025-06-18  
+;  
+  Changes (ab)
+  + Remove 'Coordination geometry' and 'Coordination number' from _pdbx_nonpoly_atom_feature_evidence.type
+    enumeration
+;
+  
+chem_comp-metallo-extension.dic         0.9    2025-06-19  
+;  
+  Changes (ab)
+  + Remove _pdbx_chem_comp_precursor_set, _pdbx_chem_comp_precursor,
+    _pdbx_chem_comp_precursor_descriptor, _pdbx_chem_comp_precursor_identifier
+  + _pdbx_depui_status_flags.metal_experiment_evidence
+;
+  
+chem_comp-metallo-extension.dic         0.10   2025-08-12  
+;  
+  Changes (ab)
+  + Add _pdbx_chem_comp_atom_coordination, _pdbx_chem_comp_atom_coordination_sphere,
+    _pdbx_nonpoly_atom_coordination, _pdbx_nonpoly_atom_coordination_sphere
+  + Remove _pdbx_nonpoly_atom_feature.assessment
+  + Update enumeration for _pdbx_nonpoly_atom_feature.type
+  + Revert any changes to _pdbx_chem_comp_atom_feature
+;
+  
+chem_comp-metallo-extension.dic         0.11   2025-08-20  
+;  
+  Changes (ab)
+  + Category keys for _chem_comp_attrom_coordination changed to _pdbx_chem_comp_atom_coordination.geometry_id
+    and _pdbx_chem_comp_atom_coordination.provenance
+  + _pdbx_chem_comp_atom_coordination.ordinal and _pdbx_nonpoly_atom_coordination.ordinal removed
+  + _pdbx_chem_comp_atom_coordination.geometry_software renamed _pdbx_chem_comp_atom_coordination.geometry.
+    _pdbx_chem_comp_atom_coordination.geometry_pdb renamed _pdbx_chem_comp_atom_coordination.geometry_generic
+  + _pdbx_nonpoly_atom_coordination category keys changed to __pdbx_nonpoly_atom_coordination.geometry_id and
+    __pdbx_nonpoly_atom_coordination.provenance.
+  + _pdbx_nonpoly_atom_coordination.alt_id and _pdbx_nonpoly_atom_coordination_sphere.alt_id added
+  + _pdbx_nonpoly_atom_coordination.geometry_software renamed _pdbx_nonpoly_atom_coordination.geometry and
+    _pdbx_nonpoly_atom_coordination.geometry_pdb renamed _pdbx_nonpoly_atom_coordination.geometry_generic
+  + Category keys for _pdbx_nonpoly_atom_coordination_sphere changed to
+   _pdbx_nonpoly_atom_coordination_sphere.geometry_id, _pdbx_nonpoly_atom_coordination_sphere.comp_id
+    and _pdbx_nonpoly_atom_coordination_sphere.atom_id
+  + _pdbx_nonpoly_atom_coordination_sphere.id removed.
+;
+  
+chem_comp-metallo-extension.dic         0.12   2025-10-17  
+;  
+  Changes (ab/ep)
+  + Add category _pdbx_nonpoly_atom_coordination_sphere_order
+  + Change attribute names in _pdbx_nonpoly_atom_coordination and
+    _pdbx_nonpoly_atom_coordination_sphere from comp_id, atom_id, alt_id
+    to label_comp_id, label_atom_id, label_alt_id
+  + Add attributes label_seq_id, auth_asym_id, auth_comp_id, auto_atom_id,
+    PDB_ins_code to _pdbx_nonpoly_atom_coordination and
+    _pdbx_nonpoly_atom_coordination_sphere
+  + Add pdbx_chem_comp_atom_coordination.geometry_abbr
+;
+  
+chem_comp-metallo-extension.dic         0.13   2025-11-24  
+;  
+  Changes (ab/ep)
+  + Remove _pdbx_nonpoly_atom_coordination.geometry, add
+    _pdbx_nonpoly_atom_coordination.geometry_calculated and
+    _pdbx_nonpoly_atom_coordination.software_remark
+  + Add _pdbx_nonpoly_atom_coordination_sphere.id
+  + Remove _pdbx_nonpoly_atom_coordination_sphere_order.geometry_id
+    and add new key _pdbx_nonpoly_atom_coordination_sphere_order.sphere_id
+    and _pdbx_nonpoly_atom_coordination_sphere_order.symmetry_operation
+  + Change _pdbx_chem_comp_atom_coordination.geometry to
+    _pdbx_chem_comp_atom_coordination.geometry_calculated
 ;
   
 #
@@ -4685,6 +5007,18 @@ em_3d_fitting_list                                         2  em_3d_fitting_list
 pdbx_chem_comp_pcm                                         1  pdbx_chem_comp_pcm:chem_comp:1                                                            .  .  
 pdbx_modification_feature                                  1  pdbx_modification_feature:atom_site:1                                                     .  .  
 pdbx_modification_feature                                  2  pdbx_modification_feature:atom_site:2                                                     .  .  
+pdbx_chem_comp_atom_coordination                           1  pdbx_chem_comp_atom_coordination:chem_comp_atom:1                                         .  .  
+pdbx_chem_comp_atom_coordination_sphere                    1  pdbx_chem_comp_atom_coordination_sphere:chem_comp_atom:1                                  .  .  
+pdbx_chem_comp_atom_coordination_sphere                    2  pdbx_chem_comp_atom_coordination_sphere:pdbx_chem_comp_atom_coordination:2                .  .  
+pdbx_nonpoly_atom_coordination                             1  pdbx_nonpoly_atom_coordination:atom_site:1                                                .  .  
+pdbx_nonpoly_atom_coordination_sphere                      1  pdbx_nonpoly_atom_coordination_sphere:atom_site:1                                         .  .  
+pdbx_nonpoly_atom_coordination_sphere                      2  pdbx_nonpoly_atom_coordination_sphere:pdbx_nonpoly_atom_coordination:1                    .  .  
+pdbx_nonpoly_atom_coordination_sphere_order                1  pdbx_nonpoly_atom_coordination_sphere_order:atom_site:1                                   .  .  
+pdbx_nonpoly_atom_coordination_sphere_order                2  pdbx_nonpoly_atom_coordination_sphere_order:pdbx_nonpoly_atom_coordination_sphere:1       .  .  
+pdbx_nonpoly_feature                                       1  pdbx_nonpoly_feature:atom_site:1                                                          .  .  
+pdbx_nonpoly_feature_evidence                              1  pdbx_nonpoly_feature_evidence:atom_site:1                                                 .  .  
+pdbx_nonpoly_atom_feature                                  1  pdbx_nonpoly_atom_feature:atom_site:1                                                     .  .  
+pdbx_nonpoly_atom_feature_evidence                         1  pdbx_nonpoly_atom_feature_evidence:atom_site:1                                            .  .  
 diffrn_refln                                               6  diffrn_refln:diffrn_scan_frame:6                                                          .  .  
 diffrn_refln                                               7  diffrn_refln:pdbx_diffrn_batch:7                                                          .  .  
 diffrn_refln                                               8  diffrn_refln:pdbx_diffrn_detector_panel_mapping:8                                         .  .  
@@ -5417,6 +5751,72 @@ pdbx_modification_feature                                  2  "_pdbx_modificatio
 pdbx_modification_feature                                  2  "_pdbx_modification_feature.modified_residue_auth_asym_id"             "_atom_site.auth_asym_id"                                   atom_site                               
 pdbx_modification_feature                                  2  "_pdbx_modification_feature.modified_residue_auth_seq_id"              "_atom_site.auth_seq_id"                                    atom_site                               
 pdbx_modification_feature                                  2  "_pdbx_modification_feature.modified_residue_PDB_ins_code"             "_atom_site.pdbx_PDB_ins_code"                              atom_site                               
+pdbx_chem_comp_atom_coordination                           1  "_pdbx_chem_comp_atom_coordination.comp_id"                            "_chem_comp_atom.comp_id"                                   chem_comp_atom                          
+pdbx_chem_comp_atom_coordination                           1  "_pdbx_chem_comp_atom_coordination.atom_id"                            "_chem_comp_atom.atom_id"                                   chem_comp_atom                          
+pdbx_chem_comp_atom_coordination_sphere                    1  "_pdbx_chem_comp_atom_coordination_sphere.comp_id"                     "_chem_comp_atom.comp_id"                                   chem_comp_atom                          
+pdbx_chem_comp_atom_coordination_sphere                    1  "_pdbx_chem_comp_atom_coordination_sphere.atom_id"                     "_chem_comp_atom.atom_id"                                   chem_comp_atom                          
+pdbx_chem_comp_atom_coordination_sphere                    2  "_pdbx_chem_comp_atom_coordination_sphere.geometry_id"                 "_pdbx_chem_comp_atom_coordination.geometry_id"             pdbx_chem_comp_atom_coordination        
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.label_comp_id"                        "_atom_site.label_comp_id"                                  atom_site                               
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.label_atom_id"                        "_atom_site.label_atom_id"                                  atom_site                               
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.label_asym_id"                        "_atom_site.label_asym_id"                                  atom_site                               
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.label_seq_id"                         "_atom_site.label_seq_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.label_alt_id"                         "_atom_site.label_alt_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.auth_asym_id"                         "_atom_site.auth_asym_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.auth_asym_id"                         "_atom_site.auth_asym_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.auth_comp_id"                         "_atom_site.auth_comp_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.auth_atom_id"                         "_atom_site.auth_atom_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination                             1  "_pdbx_nonpoly_atom_coordination.PDB_ins_code"                         "_atom_site.pdbx_PDB_ins_code"                              atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.label_comp_id"                 "_atom_site.label_comp_id"                                  atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.label_atom_id"                 "_atom_site.label_atom_id"                                  atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.label_asym_id"                 "_atom_site.label_asym_id"                                  atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.label_seq_id"                  "_atom_site.label_seq_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.label_alt_id"                  "_atom_site.label_alt_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.auth_asym_id"                  "_atom_site.auth_asym_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.auth_atom_id"                  "_atom_site.auth_atom_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.auth_seq_id"                   "_atom_site.auth_seq_id"                                    atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.auth_comp_id"                  "_atom_site.auth_comp_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      1  "_pdbx_nonpoly_atom_coordination_sphere.PDB_ins_code"                  "_atom_site.pdbx_PDB_ins_code"                              atom_site                               
+pdbx_nonpoly_atom_coordination_sphere                      2  "_pdbx_nonpoly_atom_coordination_sphere.geometry_id"                   "_pdbx_nonpoly_atom_coordination.geometry_id"               pdbx_nonpoly_atom_coordination          
+pdbx_nonpoly_atom_coordination_sphere_order                1  "_pdbx_nonpoly_atom_coordination_sphere_order.label_comp_id"           "_atom_site.label_comp_id"                                  atom_site                               
+pdbx_nonpoly_atom_coordination_sphere_order                1  "_pdbx_nonpoly_atom_coordination_sphere_order.label_atom_id"           "_atom_site.label_atom_id"                                  atom_site                               
+pdbx_nonpoly_atom_coordination_sphere_order                1  "_pdbx_nonpoly_atom_coordination_sphere_order.label_asym_id"           "_atom_site.label_asym_id"                                  atom_site                               
+pdbx_nonpoly_atom_coordination_sphere_order                1  "_pdbx_nonpoly_atom_coordination_sphere_order.label_seq_id"            "_atom_site.label_seq_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination_sphere_order                1  "_pdbx_nonpoly_atom_coordination_sphere_order.auth_asym_id"            "_atom_site.auth_asym_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination_sphere_order                1  "_pdbx_nonpoly_atom_coordination_sphere_order.auth_comp_id"            "_atom_site.auth_comp_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination_sphere_order                1  "_pdbx_nonpoly_atom_coordination_sphere_order.auth_atom_id"            "_atom_site.auth_atom_id"                                   atom_site                               
+pdbx_nonpoly_atom_coordination_sphere_order                1  "_pdbx_nonpoly_atom_coordination_sphere_order.PDB_ins_code"            "_atom_site.pdbx_PDB_ins_code"                              atom_site                               
+pdbx_nonpoly_atom_coordination_sphere_order                2  "_pdbx_nonpoly_atom_coordination_sphere_order.sphere_id"               "_pdbx_nonpoly_atom_coordination_sphere.id"                 pdbx_nonpoly_atom_coordination_sphere   
+pdbx_nonpoly_feature                                       1  "_pdbx_nonpoly_feature.label_asym_id"                                  "_atom_site.label_asym_id"                                  atom_site                               
+pdbx_nonpoly_feature                                       1  "_pdbx_nonpoly_feature.label_comp_id"                                  "_atom_site.label_comp_id"                                  atom_site                               
+pdbx_nonpoly_feature                                       1  "_pdbx_nonpoly_feature.label_seq_id"                                   "_atom_site.label_seq_id"                                   atom_site                               
+pdbx_nonpoly_feature                                       1  "_pdbx_nonpoly_feature.auth_asym_id"                                   "_atom_site.auth_asym_id"                                   atom_site                               
+pdbx_nonpoly_feature                                       1  "_pdbx_nonpoly_feature.auth_seq_id"                                    "_atom_site.auth_seq_id"                                    atom_site                               
+pdbx_nonpoly_feature                                       1  "_pdbx_nonpoly_feature.auth_comp_id"                                   "_atom_site.auth_comp_id"                                   atom_site                               
+pdbx_nonpoly_feature                                       1  "_pdbx_nonpoly_feature.PDB_ins_code"                                   "_atom_site.pdbx_PDB_ins_code"                              atom_site                               
+pdbx_nonpoly_atom_feature                                  1  "_pdbx_nonpoly_atom_feature.label_comp_id"                             "_atom_site.label_comp_id"                                  atom_site                               
+pdbx_nonpoly_atom_feature                                  1  "_pdbx_nonpoly_atom_feature.label_atom_id"                             "_atom_site.label_atom_id"                                  atom_site                               
+pdbx_nonpoly_atom_feature                                  1  "_pdbx_nonpoly_atom_feature.label_asym_id"                             "_atom_site.label_asym_id"                                  atom_site                               
+pdbx_nonpoly_atom_feature                                  1  "_pdbx_nonpoly_atom_feature.label_seq_id"                              "_atom_site.label_seq_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature                                  1  "_pdbx_nonpoly_atom_feature.label_alt_id"                              "_atom_site.label_alt_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature                                  1  "_pdbx_nonpoly_atom_feature.auth_asym_id"                              "_atom_site.auth_asym_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature                                  1  "_pdbx_nonpoly_atom_feature.auth_comp_id"                              "_atom_site.auth_comp_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature                                  1  "_pdbx_nonpoly_atom_feature.auth_atom_id"                              "_atom_site.auth_atom_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature                                  1  "_pdbx_nonpoly_atom_feature.PDB_ins_code"                              "_atom_site.pdbx_PDB_ins_code"                              atom_site                               
+pdbx_nonpoly_feature_evidence                              1  "_pdbx_nonpoly_feature_evidence.label_comp_id"                         "_atom_site.label_comp_id"                                  atom_site                               
+pdbx_nonpoly_feature_evidence                              1  "_pdbx_nonpoly_feature_evidence.label_asym_id"                         "_atom_site.label_asym_id"                                  atom_site                               
+pdbx_nonpoly_feature_evidence                              1  "_pdbx_nonpoly_feature_evidence.label_seq_id"                          "_atom_site.label_seq_id"                                   atom_site                               
+pdbx_nonpoly_feature_evidence                              1  "_pdbx_nonpoly_feature_evidence.auth_asym_id"                          "_atom_site.auth_asym_id"                                   atom_site                               
+pdbx_nonpoly_feature_evidence                              1  "_pdbx_nonpoly_feature_evidence.auth_comp_id"                          "_atom_site.auth_comp_id"                                   atom_site                               
+pdbx_nonpoly_feature_evidence                              1  "_pdbx_nonpoly_feature_evidence.PDB_ins_code"                          "_atom_site.pdbx_PDB_ins_code"                              atom_site                               
+pdbx_nonpoly_atom_feature_evidence                         1  "_pdbx_nonpoly_atom_feature_evidence.label_comp_id"                    "_atom_site.label_comp_id"                                  atom_site                               
+pdbx_nonpoly_atom_feature_evidence                         1  "_pdbx_nonpoly_atom_feature_evidence.label_atom_id"                    "_atom_site.label_atom_id"                                  atom_site                               
+pdbx_nonpoly_atom_feature_evidence                         1  "_pdbx_nonpoly_atom_feature_evidence.label_asym_id"                    "_atom_site.label_asym_id"                                  atom_site                               
+pdbx_nonpoly_atom_feature_evidence                         1  "_pdbx_nonpoly_atom_feature_evidence.label_seq_id"                     "_atom_site.label_seq_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature_evidence                         1  "_pdbx_nonpoly_atom_feature_evidence.label_alt_id"                     "_atom_site.label_alt_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature_evidence                         1  "_pdbx_nonpoly_atom_feature_evidence.auth_asym_id"                     "_atom_site.auth_asym_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature_evidence                         1  "_pdbx_nonpoly_atom_feature_evidence.auth_comp_id"                     "_atom_site.auth_comp_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature_evidence                         1  "_pdbx_nonpoly_atom_feature_evidence.auth_atom_id"                     "_atom_site.auth_atom_id"                                   atom_site                               
+pdbx_nonpoly_atom_feature_evidence                         1  "_pdbx_nonpoly_atom_feature_evidence.PDB_ins_code"                     "_atom_site.pdbx_PDB_ins_code"                              atom_site                               
 diffrn_refln                                               6  "_diffrn_refln.frame_id"                                               "_diffrn_scan_frame.frame_id"                               diffrn_scan_frame                       
 diffrn_refln                                               7  "_diffrn_refln.pdbx_batch_id"                                          "_pdbx_diffrn_batch.id"                                     pdbx_diffrn_batch                       
 diffrn_refln                                               8  "_diffrn_refln.pdbx_panel_mapping_id"                                  "_pdbx_diffrn_detector_panel_mapping.id"                    pdbx_diffrn_detector_panel_mapping      
@@ -21821,6 +22221,8 @@ save__diffrn_detector.type
      "_diffrn_detector.type"  "CS-PAD CXI-2"                     PIXEL  
      "_diffrn_detector.type"  "CS-PAD XPP"                       PIXEL  
      "_diffrn_detector.type"  "Cyberstar LaBr3"                  SCINTILLATION  
+     "_diffrn_detector.type"  "DECTRIS ARINA"                    PIXEL  
+     "_diffrn_detector.type"  "DECTRIS ELA"                      PIXEL  
      "_diffrn_detector.type"  "DECTRIS EIGER R 1M"               PIXEL  
      "_diffrn_detector.type"  "DECTRIS EIGER R 4M"               PIXEL  
      "_diffrn_detector.type"  "DECTRIS EIGER X 500K"             PIXEL  
@@ -21850,6 +22252,7 @@ save__diffrn_detector.type
      "_diffrn_detector.type"  "DECTRIS MYTHEN2 R 1D"             PIXEL  
      "_diffrn_detector.type"  "DECTRIS MYTHEN2 X 1K"             PIXEL  
      "_diffrn_detector.type"  "DECTRIS MYTHEN2 X 1D"             PIXEL  
+     "_diffrn_detector.type"  "DECTRIS PILATUS 1M"               PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS 200K"             PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS 300K"             PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS 2M"               PIXEL  
@@ -21857,6 +22260,7 @@ save__diffrn_detector.type
      "_diffrn_detector.type"  "DECTRIS PILATUS 6M"               PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS 6M-F"             PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS 12M"              PIXEL  
+     "_diffrn_detector.type"  "DECTRIS PILATUS 12M-DLS"          PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS3 100K-M"          PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS3 2M"              PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS3 6M"              PIXEL  
@@ -21893,6 +22297,8 @@ save__diffrn_detector.type
      "_diffrn_detector.type"  "DECTRIS PILATUS4 XE 4M"           PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS4 XE CdTe 2M"      PIXEL  
      "_diffrn_detector.type"  "DECTRIS PILATUS4 XE CdTe 4M"      PIXEL  
+     "_diffrn_detector.type"  "DECTRIS QUADRO"                   PIXEL  
+     "_diffrn_detector.type"  "DECTRIS SINGLA"                   PIXEL  
      "_diffrn_detector.type"  ENRAF-NONIUS                       .  
      "_diffrn_detector.type"  "ENRAF-NONIUS CAD4"                DIFFRACTOMETER  
      "_diffrn_detector.type"  "ENRAF-NONIUS FAST"                DIFFRACTOMETER  
@@ -25053,6 +25459,7 @@ save__diffrn_source.type
      "_diffrn_source.type"  "AichiSR BEAMLINE BL2S1"                         SYNCHROTRON  
      "_diffrn_source.type"  "Agilent SuperNova"                              "SEALED TUBE"  
      "_diffrn_source.type"  "ALBA BEAMLINE XALOC"                            SYNCHROTRON  
+     "_diffrn_source.type"  "ALBA BEAMLINE XAIRA"                            SYNCHROTRON  
      "_diffrn_source.type"  "ALS BEAMLINE 2.0.1"                             SYNCHROTRON  
      "_diffrn_source.type"  "ALS BEAMLINE 4.2.2"                             SYNCHROTRON  
      "_diffrn_source.type"  "ALS BEAMLINE 5.0.1"                             SYNCHROTRON  
@@ -25089,6 +25496,7 @@ save__diffrn_source.type
      "_diffrn_source.type"  "APS BEAMLINE 34-ID"                             SYNCHROTRON  
      "_diffrn_source.type"  "AUSTRALIAN SYNCHROTRON BEAMLINE MX1"            SYNCHROTRON  
      "_diffrn_source.type"  "AUSTRALIAN SYNCHROTRON BEAMLINE MX2"            SYNCHROTRON  
+     "_diffrn_source.type"  "AUSTRALIAN SYNCHROTRON BEAMLINE MX3"            SYNCHROTRON  
      "_diffrn_source.type"  "BESSY BEAMLINE 14.1"                            SYNCHROTRON  
      "_diffrn_source.type"  "BESSY BEAMLINE 14.2"                            SYNCHROTRON  
      "_diffrn_source.type"  "BESSY BEAMLINE 14.3"                            SYNCHROTRON  
@@ -25170,7 +25578,7 @@ save__diffrn_source.type
      "_diffrn_source.type"  "Excillum MetalJet D2+ 160 kV"                   "LIQUID ANODE"  
      "_diffrn_source.type"  "FRM II BEAMLINE ANTARES"                        "NUCLEAR REACTOR"  
      "_diffrn_source.type"  "FRM II BEAMLINE BIODIFF"                        "NUCLEAR REACTOR"  
-     "_diffrn_source.type"  "KURCHATOV SNC BEAMLINE K4.4"                    SYNCHROTRON  
+     "_diffrn_source.type"  "HEPS BEAMLINE ID02U1A"                          SYNCHROTRON  
      "_diffrn_source.type"  "ILL BEAMLINE D11"                               "NUCLEAR REACTOR"  
      "_diffrn_source.type"  "ILL BEAMLINE D16"                               "NUCLEAR REACTOR"  
      "_diffrn_source.type"  "ILL BEAMLINE D19"                               "NUCLEAR REACTOR"  
@@ -25184,6 +25592,7 @@ save__diffrn_source.type
      "_diffrn_source.type"  "JRR-3M BEAMLINE 1G-A"                           "NUCLEAR REACTOR"  
      "_diffrn_source.type"  "JRR-3M BEAMLINE 1G-B"                           "NUCLEAR REACTOR"  
      "_diffrn_source.type"  "JRR-3M BEAMLINE 1G-C"                           "NUCLEAR REACTOR"  
+     "_diffrn_source.type"  "KURCHATOV SNC BEAMLINE K4.4"                    SYNCHROTRON  
      "_diffrn_source.type"  "LaB6 thermoionic"                               .  
      "_diffrn_source.type"  "LANSCE BEAMLINE BL03"                           "NUCLEAR REACTOR"  
      "_diffrn_source.type"  "LANSCE BEAMLINE PCS"                            "NUCLEAR REACTOR"  
@@ -25207,6 +25616,7 @@ save__diffrn_source.type
      "_diffrn_source.type"  "MAX IV BEAMLINE BioMAX"                         SYNCHROTRON  
      "_diffrn_source.type"  "MAX IV BEAMLINE MicroMAX"                       SYNCHROTRON  
      "_diffrn_source.type"  "MPG/DESY, HAMBURG BEAMLINE BW6"                 SYNCHROTRON  
+     "_diffrn_source.type"  "NanoTerasu BEAMLINE BL09U MX-ES"                SYNCHROTRON  
      "_diffrn_source.type"  "NFPSS BEAMLINE BL17B"                           SYNCHROTRON  
      "_diffrn_source.type"  "NFPSS BEAMLINE BL18U"                           SYNCHROTRON  
      "_diffrn_source.type"  "NFPSS BEAMLINE BL19U1"                          SYNCHROTRON  
@@ -46420,226 +46830,242 @@ save__software.name
    _pdbx_item_enumeration.name
    _pdbx_item_enumeration.value
    _pdbx_item_enumeration.detail
-     "_software.name"  ABS                 .  
-     "_software.name"  ABSCALE             .  
-     "_software.name"  ABSCOR              .  
-     "_software.name"  ACORN               phasing  
-     "_software.name"  ADDREF              "data scaling,data reduction"  
-     "_software.name"  ADSC                "data collection"  
-     "_software.name"  Adxv                "data reduction"  
-     "_software.name"  Agrovata            .  
-     "_software.name"  Aimless             "data scaling"  
-     "_software.name"  AMBER               refinement  
-     "_software.name"  AMoRE               phasing  
-     "_software.name"  AMPLE               phasing  
-     "_software.name"  APEX                "data collection,data scaling,data reduction"  
-     "_software.name"  "APEX 2"            "data collection,data scaling,data reduction"  
-     "_software.name"  APRV                .  
-     "_software.name"  Arcimboldo          phasing  
-     "_software.name"  ARP                 "model building"  
-     "_software.name"  ARP/wARP            "model building"  
-     "_software.name"  Auto-Rickshaw       phasing  
-     "_software.name"  autoBUSTER          phasing,refinement  
-     "_software.name"  AUTOMAR             "data collection,data reduction"  
-     "_software.name"  autoPROC            "data processing,data reduction,data scaling"  
-     "_software.name"  AutoProcess         .  
-     "_software.name"  autoPX              "data processing,data reduction"  
-     "_software.name"  autoSHARP           phasing  
-     "_software.name"  AutoSol             phasing  
-     "_software.name"  autoXDS             .  
-     "_software.name"  Babel               .  
-     "_software.name"  BALBES              phasing  
-     "_software.name"  BEAST               .  
-     "_software.name"  BILDER              .  
-     "_software.name"  BIOMOL              "data reduction,data scaling,model building"  
-     "_software.name"  bioteX              "data collection,data reduction,data scaling"  
-     "_software.name"  Blu-Ice             "data collection"  
-     "_software.name"  BLU-MAX             "data collection"  
-     "_software.name"  BOS                 "data collection"  
-     "_software.name"  BRUTE               "phasing,model building"  
-     "_software.name"  BSS                 "data collection"  
-     "_software.name"  BUCCANEER           "phasing,model building"  
-     "_software.name"  BUSTER              refinement,phasing  
-     "_software.name"  careless            "data reduction,data scaling"  
-     "_software.name"  CaspR               .  
-     "_software.name"  CBASS               "data collection"  
-     "_software.name"  cctbx.prime         "data scaling"  
-     "_software.name"  cctbx.xfel          "data reduction"  
-     "_software.name"  cctbx.xfel.merge    "data scaling"  
-     "_software.name"  CHAINSAW            .  
-     "_software.name"  Cheetah             "data collection,data collection"  
-     "_software.name"  CNS                 refinement,phasing  
-     "_software.name"  CNX                 refinement,phasing  
-     "_software.name"  COMBAT              .  
-     "_software.name"  COMO                phasing  
-     "_software.name"  Coot                "model building"  
-     "_software.name"  CORELS              refinement  
-     "_software.name"  CRANK               phasing  
-     "_software.name"  CRANK2              phasing  
-     "_software.name"  CRISpy              "data collection"  
-     "_software.name"  CrysalisPro         "data collection,data scaling,data reduction"  
-     "_software.name"  CrystalClear        "data collection,data scaling,data reduction,phasing"  
-     "_software.name"  CrystFEL            "data collection,data scaling,data reduction"  
-     "_software.name"  CSearch             phasing  
-     "_software.name"  cxi.merge           "data scaling"  
-     "_software.name"  d*TREK              "data scaling,data reduction"  
-     "_software.name"  DENZO               "data reduction"  
-     "_software.name"  DIALS               "data collection,data scaling,data reduction"  
-     "_software.name"  DIFDAT              "data reduction"  
-     "_software.name"  DIMPLE              .  
-     "_software.name"  DirAx               "data reduction"  
-     "_software.name"  DM                  "phasing,model building"  
-     "_software.name"  DMMulti             "phasing,model building"  
-     "_software.name"  DNA                 "data collection"  
-     "_software.name"  DPS                 "data collection,data reduction"  
-     "_software.name"  EDNA                "data collection"  
-     "_software.name"  ELVES               "data processing,data reduction,data scaling,model building,phasing,refinement"  
-     "_software.name"  Epinorm             "data reduction"  
-     "_software.name"  EPMR                phasing  
-     "_software.name"  EREF                refinement  
-     "_software.name"  EVAL15              "data scaling,data reduction"  
-     "_software.name"  FAST_DP             "data scaling,data reduction"  
-     "_software.name"  FFFEAR              .  
-     "_software.name"  FFT                 "phasing,model building"  
-     "_software.name"  "Force Field X"     refinement  
-     "_software.name"  Fragon              phasing  
-     "_software.name"  FRAMBO              "data collection"  
-     "_software.name"  FRFS                phasing  
-     "_software.name"  FRODO               "model building"  
-     "_software.name"  gemmi               "data extraction"  
-     "_software.name"  GDA                 "data collection"  
-     "_software.name"  GLRF                phasing  
-     "_software.name"  GPRLSA              refinement  
-     "_software.name"  GSAS                refinement  
-     "_software.name"  HKL-2000            "data collection,data scaling,data reduction"  
-     "_software.name"  HKL-3000            "data collection,data scaling,data reduction,phasing"  
-     "_software.name"  HKL2Map             "phasing,model building"  
-     "_software.name"  "Insight II"        "model building"  
-     "_software.name"  ISOLDE              "model building"  
-     "_software.name"  iMOSFLM             "data reduction"  
-     "_software.name"  IPCAS               "phasing,model building,refinement"  
-     "_software.name"  ISOLDE              refinement  
-     "_software.name"  ISIR                phasing  
-     "_software.name"  JACK-LEVITT         refinement  
-     "_software.name"  JBluIce-EPICS       "data collection"  
-     "_software.name"  JDirector           "data collection"  
-     "_software.name"  KYLIN               "data scaling,data reduction"  
-     "_software.name"  LAUEGEN             .  
-     "_software.name"  LAUENORM            "data scaling"  
-     "_software.name"  LaueView            "data reduction,data scaling"  
-     "_software.name"  LSCALE              .  
-     "_software.name"  MADNESS             .  
-     "_software.name"  MADSYS              phasing  
-     "_software.name"  MAIN                "refinement,model building"  
-     "_software.name"  Mantid              "data reduction"  
-     "_software.name"  MAR345              "data collection"  
-     "_software.name"  MAR345dtb           "data collection"  
-     "_software.name"  MD2                 .  
-     "_software.name"  MERLOT              phasing  
-     "_software.name"  MLPHARE             phasing  
-     "_software.name"  MOLEMAN2            .  
-     "_software.name"  MolProbity          "model building"  
-     "_software.name"  MOLREP              phasing  
-     "_software.name"  MoRDa               phasing  
-     "_software.name"  MOSFLM              "data reduction"  
-     "_software.name"  MxDC                "data collection"  
-     "_software.name"  MR-Rosetta          phasing  
-     "_software.name"  MrBUMP              phasing  
-     "_software.name"  MxCuBE              "data collection"  
-     "_software.name"  nCNS                refinement,phasing  
-     "_software.name"  NUCLSQ              refinement  
-     "_software.name"  O                   "model building"  
-     "_software.name"  OASIS               "phasing,model building"  
-     "_software.name"  PARROT              phasing  
-     "_software.name"  PDB_EXTRACT         "data extraction"  
-     "_software.name"  PDB-REDO            refinement  
-     "_software.name"  PDBSET              .  
-     "_software.name"  PHASER              phasing  
-     "_software.name"  PHASES              phasing  
-     "_software.name"  PHENIX              "refinement,phasing,model building"  
-     "_software.name"  pirate              phasing  
-     "_software.name"  pointless           "data scaling"  
-     "_software.name"  Precognition        "data reduction"  
-     "_software.name"  PRIME               "data scaling"  
-     "_software.name"  PRIME-X             refinement  
-     "_software.name"  PROCESS             .  
-     "_software.name"  PROCOR              "data reduction,data scaling"  
-     "_software.name"  ProDC               "data collection"  
-     "_software.name"  PRODD               "data extraction,data processing,data reduction"  
-     "_software.name"  PROFFT              refinement  
-     "_software.name"  PROLSQ              refinement  
-     "_software.name"  PROTEUM             .  
-     "_software.name"  "PROTEUM PLUS"      "data collection,data scaling,data reduction"  
-     "_software.name"  PROTEUM2            .  
-     "_software.name"  Quanta              "model building"  
-     "_software.name"  "Queen of Spades"   .  
-     "_software.name"  RAPD                "data processing,data reduction,data scaling"  
-     "_software.name"  RANTAN              .  
-     "_software.name"  RAVE                .  
-     "_software.name"  REFMAC              refinement,phasing  
-     "_software.name"  REFPK               "data processing"  
-     "_software.name"  RemDAq              "data collection"  
-     "_software.name"  RESOLVE             "phasing,model building"  
-     "_software.name"  RESTRAIN            refinement  
-     "_software.name"  Rosetta             .  
-     "_software.name"  ROTAPREP            .  
-     "_software.name"  ROTAVATA            .  
-     "_software.name"  RSPS                .  
-     "_software.name"  SADABS              "data scaling,data reduction"  
-     "_software.name"  SAINT               "data scaling,data reduction"  
-     "_software.name"  SBC-Collect         "data collection"  
-     "_software.name"  SCALA               "data scaling"  
-     "_software.name"  SCALEIT             .  
-     "_software.name"  SCALEPACK           "data scaling"  
-     "_software.name"  SDMS                "data collection,data processing,data reduction,data scaling"  
-     "_software.name"  SERGUI              "data collection"  
-     "_software.name"  Servalcat           refinement  
-     "_software.name"  SGXPRO              "phasing,model building"  
-     "_software.name"  SHARP               phasing  
-     "_software.name"  SHELX               .  
-     "_software.name"  SHELXCD             phasing  
-     "_software.name"  SHELXD              phasing  
-     "_software.name"  SHELXDE             phasing  
-     "_software.name"  SHELXE              "model building"  
-     "_software.name"  SHELXL              refinement  
-     "_software.name"  SHELXL-97           .  
-     "_software.name"  SHELXPREP           "data scaling"  
-     "_software.name"  SHELXS              phasing  
-     "_software.name"  SHELXT              phasing  
-     "_software.name"  SIGMAA              .  
-     "_software.name"  SIMBAD              phasing  
-     "_software.name"  Sir2014             phasing  
-     "_software.name"  SnB                 phasing  
-     "_software.name"  SOLOMON             phasing  
-     "_software.name"  SOLVE               phasing  
-     "_software.name"  SORTAV              "data reduction,data scaling"  
-     "_software.name"  SORTRF              "data scaling"  
-     "_software.name"  SQUASH              phasing  
-     "_software.name"  STARGazer           "data reduction"  
-     "_software.name"  STARANISO           "data scaling"  
-     "_software.name"  StructureStudio     "data collection"  
-     "_software.name"  TFFC                .  
-     "_software.name"  TFORM               phasing  
-     "_software.name"  TNT                 refinement,phasing  
-     "_software.name"  TRUNCATE            .  
-     "_software.name"  ULTIMA              phasing  
-     "_software.name"  Vagabond            refinement  
-     "_software.name"  UCSD-system         "data collection,data reduction,data scaling,data processing"  
-     "_software.name"  WARP                "model building"  
-     "_software.name"  WEIS                "data reduction,data scaling"  
-     "_software.name"  Web-Ice             "data collection"  
-     "_software.name"  X-Area              "data collection,data scaling,data reduction"  
-     "_software.name"  X-GEN               "data reduction,data scaling"  
-     "_software.name"  X-PLOR              "refinement,phasing,model building"  
-     "_software.name"  XDS                 "data scaling,data reduction"  
-     "_software.name"  XFIT                "data reduction"  
-     "_software.name"  xia2                "data scaling,data reduction"  
-     "_software.name"  xia2.multiplex      "data scaling,data reduction"  
-     "_software.name"  XPREP               "data reduction"  
-     "_software.name"  XSCALE              "data scaling"  
-     "_software.name"  XTALVIEW            refinement  
-     "_software.name"  Xtrapol8            "refinement,data scaling"  
-     "_software.name"  Zanuda              "data reduction"  
+     "_software.name"  ABS                             .  
+     "_software.name"  ABSCALE                         .  
+     "_software.name"  ABSCOR                          .  
+     "_software.name"  ACORN                           phasing  
+     "_software.name"  ADDREF                          "data scaling,data reduction"  
+     "_software.name"  ADSC                            "data collection"  
+     "_software.name"  Adxv                            "data reduction"  
+     "_software.name"  Agrovata                        .  
+     "_software.name"  Aimless                         "data scaling"  
+     "_software.name"  AMBER                           refinement  
+     "_software.name"  AMoRE                           phasing  
+     "_software.name"  AMPLE                           phasing  
+     "_software.name"  APEX                            "data collection,data scaling,data reduction"  
+     "_software.name"  "APEX 2"                        "data collection,data scaling,data reduction"  
+     "_software.name"  APRV                            .  
+     "_software.name"  Arcimboldo                      phasing  
+     "_software.name"  ARP                             "model building"  
+     "_software.name"  ARP/wARP                        "model building"  
+     "_software.name"  AutoPD                          "data processing,phasing,data reduction,data scaling,model building"  
+     "_software.name"  Auto-Rickshaw                   phasing  
+     "_software.name"  autoBUSTER                      phasing,refinement  
+     "_software.name"  AUTOMAR                         "data collection,data reduction"  
+     "_software.name"  autoPROC                        "data processing,data reduction,data scaling"  
+     "_software.name"  AutoProcess                     .  
+     "_software.name"  autoPX                          "data processing,data reduction"  
+     "_software.name"  autoSHARP                       phasing  
+     "_software.name"  AutoSol                         phasing  
+     "_software.name"  autoXDS                         .  
+     "_software.name"  Babel                           .  
+     "_software.name"  BALBES                          phasing  
+     "_software.name"  BEAST                           .  
+     "_software.name"  BILDER                          .  
+     "_software.name"  BIOMOL                          "data reduction,data scaling,model building"  
+     "_software.name"  bioteX                          "data collection,data reduction,data scaling"  
+     "_software.name"  Blu-Ice                         "data collection"  
+     "_software.name"  BLU-MAX                         "data collection"  
+     "_software.name"  BOS                             "data collection"  
+     "_software.name"  BRUTE                           "phasing,model building"  
+     "_software.name"  BSS                             "data collection"  
+     "_software.name"  BUCCANEER                       "phasing,model building"  
+     "_software.name"  BUSTER                          refinement,phasing  
+     "_software.name"  careless                        "data reduction,data scaling"  
+     "_software.name"  CaspR                           .  
+     "_software.name"  CBASS                           "data collection"  
+     "_software.name"  cctbx.prime                     "data scaling"  
+     "_software.name"  cctbx.xfel                      "data reduction"  
+     "_software.name"  cctbx.xfel.merge                "data scaling"  
+     "_software.name"  CHAINSAW                        .  
+     "_software.name"  Cheetah                         "data collection,data collection"  
+     "_software.name"  CNS                             refinement,phasing  
+     "_software.name"  CNX                             refinement,phasing  
+     "_software.name"  COMBAT                          .  
+     "_software.name"  COMO                            phasing  
+     "_software.name"  Coot                            "model building"  
+     "_software.name"  CORELS                          refinement  
+     "_software.name"  CRANK                           phasing  
+     "_software.name"  CRANK2                          phasing  
+     "_software.name"  CRISpy                          "data collection"  
+     "_software.name"  CrysalisPro                     "data collection,data scaling,data reduction"  
+     "_software.name"  CrystalClear                    "data collection,data scaling,data reduction,phasing"  
+     "_software.name"  CrystFEL                        "data collection,data scaling,data reduction"  
+     "_software.name"  CSearch                         phasing  
+     "_software.name"  cxi.merge                       "data scaling"  
+     "_software.name"  d*TREK                          "data scaling,data reduction"  
+     "_software.name"  DENZO                           "data reduction"  
+     "_software.name"  DIALS                           "data collection,data scaling,data reduction"  
+     "_software.name"  DIFDAT                          "data reduction"  
+     "_software.name"  DigitalMicrograph               "data collection"  
+     "_software.name"  DIMPLE                          "phasing,model building"  
+     "_software.name"  DirAx                           "data reduction"  
+     "_software.name"  DM                              "phasing,model building"  
+     "_software.name"  DMMulti                         "phasing,model building"  
+     "_software.name"  DNA                             "data collection"  
+     "_software.name"  DPS                             "data collection,data reduction"  
+     "_software.name"  EDNA                            "data collection"  
+     "_software.name"  ELVES                           "data processing,data reduction,data scaling,model building,phasing,refinement"  
+     "_software.name"  Epinorm                         "data reduction"  
+     "_software.name"  EM-Menu                         "data collection"  
+     "_software.name"  EPMR                            phasing  
+     "_software.name"  EPU                             "data collection"  
+     "_software.name"  EREF                            refinement  
+     "_software.name"  EVAL15                          "data scaling,data reduction"  
+     "_software.name"  FAST_DP                         "data scaling,data reduction"  
+     "_software.name"  FFFEAR                          .  
+     "_software.name"  FFT                             "phasing,model building"  
+     "_software.name"  FOCUS                           "data collection"  
+     "_software.name"  Foldhunter                      "model building"  
+     "_software.name"  "Force Field X"                 refinement  
+     "_software.name"  Fragon                          phasing  
+     "_software.name"  FRAMBO                          "data collection"  
+     "_software.name"  FRFS                            phasing  
+     "_software.name"  FRODO                           "model building"  
+     "_software.name"  gemmi                           "data extraction"  
+     "_software.name"  GDA                             "data collection"  
+     "_software.name"  GLRF                            phasing  
+     "_software.name"  GPRLSA                          refinement  
+     "_software.name"  GSAS                            refinement  
+     "_software.name"  HKL-2000                        "data collection,data scaling,data reduction"  
+     "_software.name"  HKL-3000                        "data collection,data scaling,data reduction,phasing"  
+     "_software.name"  HKL2Map                         "phasing,model building"  
+     "_software.name"  "Insight II"                    "model building"  
+     "_software.name"  IPET                            "data reduction,data scaling,model building"  
+     "_software.name"  ISOLDE                          "model building"  
+     "_software.name"  iMOSFLM                         "data reduction"  
+     "_software.name"  IPCAS                           "phasing,model building,refinement"  
+     "_software.name"  ISOLDE                          refinement  
+     "_software.name"  ISIR                            phasing  
+     "_software.name"  JACK-LEVITT                     refinement  
+     "_software.name"  JBluIce-EPICS                   "data collection"  
+     "_software.name"  JDirector                       "data collection"  
+     "_software.name"  KYLIN                           "data scaling,data reduction"  
+     "_software.name"  LATLINE                         "data reduction,data scaling"  
+     "_software.name"  LAUEGEN                         .  
+     "_software.name"  LAUENORM                        "data scaling"  
+     "_software.name"  Laueprocess                     "data reduction,data scaling"  
+     "_software.name"  LaueView                        "data reduction,data scaling"  
+     "_software.name"  LSCALE                          .  
+     "_software.name"  MADNESS                         .  
+     "_software.name"  MADSYS                          phasing  
+     "_software.name"  MAIN                            "refinement,model building"  
+     "_software.name"  Mantid                          "data reduction"  
+     "_software.name"  MAR345                          "data collection"  
+     "_software.name"  MAR345dtb                       "data collection"  
+     "_software.name"  "MRC IMAGE PROCESSING PACKAGE"  "data reduction,data scaling"  
+     "_software.name"  MD2                             .  
+     "_software.name"  MERLOT                          phasing  
+     "_software.name"  MLPHARE                         phasing  
+     "_software.name"  MOLEMAN2                        .  
+     "_software.name"  MolProbity                      "model building"  
+     "_software.name"  MOLREP                          phasing  
+     "_software.name"  MoRDa                           phasing  
+     "_software.name"  MOSFLM                          "data reduction"  
+     "_software.name"  MxDC                            "data collection"  
+     "_software.name"  MR-Rosetta                      phasing  
+     "_software.name"  MrBUMP                          phasing  
+     "_software.name"  MxCuBE                          "data collection"  
+     "_software.name"  nCNS                            refinement,phasing  
+     "_software.name"  NMFF-EM                         "model building"  
+     "_software.name"  NUCLSQ                          refinement  
+     "_software.name"  O                               "model building"  
+     "_software.name"  OASIS                           "phasing,model building"  
+     "_software.name"  PARROT                          phasing  
+     "_software.name"  PDB_EXTRACT                     "data extraction"  
+     "_software.name"  PDB-REDO                        refinement  
+     "_software.name"  PDBSET                          .  
+     "_software.name"  PHASER                          phasing  
+     "_software.name"  PHASES                          phasing  
+     "_software.name"  PHENIX                          "refinement,phasing,model building"  
+     "_software.name"  pirate                          phasing  
+     "_software.name"  pointless                       "data scaling"  
+     "_software.name"  Precognition                    "data reduction"  
+     "_software.name"  PRIME                           "data scaling"  
+     "_software.name"  PRIME-X                         refinement  
+     "_software.name"  PROCESS                         .  
+     "_software.name"  PROCOR                          "data reduction,data scaling"  
+     "_software.name"  ProDC                           "data collection"  
+     "_software.name"  PRODD                           "data extraction,data processing,data reduction"  
+     "_software.name"  PROFFT                          refinement  
+     "_software.name"  PROLSQ                          refinement  
+     "_software.name"  PROTEUM                         .  
+     "_software.name"  "PROTEUM PLUS"                  "data collection,data scaling,data reduction"  
+     "_software.name"  PROTEUM2                        .  
+     "_software.name"  PROTOMO                         "model building"  
+     "_software.name"  Quanta                          "model building"  
+     "_software.name"  "Queen of Spades"               .  
+     "_software.name"  RAPD                            "data processing,data reduction,data scaling"  
+     "_software.name"  RANTAN                          .  
+     "_software.name"  RAVE                            .  
+     "_software.name"  REFMAC                          refinement,phasing  
+     "_software.name"  REFPK                           "data processing"  
+     "_software.name"  RemDAq                          "data collection"  
+     "_software.name"  RESOLVE                         "phasing,model building"  
+     "_software.name"  RESTRAIN                        refinement  
+     "_software.name"  Rosetta                         .  
+     "_software.name"  ROTAPREP                        .  
+     "_software.name"  ROTAVATA                        .  
+     "_software.name"  RSPS                            .  
+     "_software.name"  SADABS                          "data scaling,data reduction"  
+     "_software.name"  SAINT                           "data scaling,data reduction"  
+     "_software.name"  SBC-Collect                     "data collection"  
+     "_software.name"  SCALA                           "data scaling"  
+     "_software.name"  SCALEIT                         .  
+     "_software.name"  SCALEPACK                       "data scaling"  
+     "_software.name"  SDMS                            "data collection,data processing,data reduction,data scaling"  
+     "_software.name"  SERGUI                          "data collection"  
+     "_software.name"  SerialEM                        "data collection"  
+     "_software.name"  Servalcat                       refinement  
+     "_software.name"  SGXPRO                          "phasing,model building"  
+     "_software.name"  SHARP                           phasing  
+     "_software.name"  SHELX                           .  
+     "_software.name"  SHELXCD                         phasing  
+     "_software.name"  SHELXD                          phasing  
+     "_software.name"  SHELXDE                         phasing  
+     "_software.name"  SHELXE                          "model building"  
+     "_software.name"  SHELXL                          refinement  
+     "_software.name"  SHELXL-97                       .  
+     "_software.name"  SHELXPREP                       "data scaling"  
+     "_software.name"  SHELXS                          phasing  
+     "_software.name"  SHELXT                          phasing  
+     "_software.name"  SIGMAA                          .  
+     "_software.name"  SIMBAD                          phasing  
+     "_software.name"  Sir2014                         phasing  
+     "_software.name"  SITUS                           "model building"  
+     "_software.name"  SnB                             phasing  
+     "_software.name"  SOLOMON                         phasing  
+     "_software.name"  SOLVE                           phasing  
+     "_software.name"  SORTAV                          "data reduction,data scaling"  
+     "_software.name"  SORTRF                          "data scaling"  
+     "_software.name"  SQUASH                          phasing  
+     "_software.name"  STARGazer                       "data reduction"  
+     "_software.name"  STARANISO                       "data scaling"  
+     "_software.name"  StructureStudio                 "data collection"  
+     "_software.name"  TFFC                            .  
+     "_software.name"  TFORM                           phasing  
+     "_software.name"  TIA                             "data collection"  
+     "_software.name"  TNT                             refinement,phasing  
+     "_software.name"  TRUNCATE                        .  
+     "_software.name"  ULTIMA                          phasing  
+     "_software.name"  Vagabond                        refinement  
+     "_software.name"  Velox                           "data collection"  
+     "_software.name"  UCSD-system                     "data collection,data reduction,data scaling,data processing"  
+     "_software.name"  WARP                            "model building"  
+     "_software.name"  WEIS                            "data reduction,data scaling"  
+     "_software.name"  Web-Ice                         "data collection"  
+     "_software.name"  X-Area                          "data collection,data scaling,data reduction"  
+     "_software.name"  X-GEN                           "data reduction,data scaling"  
+     "_software.name"  X-PLOR                          "refinement,phasing,model building"  
+     "_software.name"  XDS                             "data scaling,data reduction"  
+     "_software.name"  XFIT                            "data reduction"  
+     "_software.name"  xia2                            "data scaling,data reduction"  
+     "_software.name"  xia2.multiplex                  "data scaling,data reduction"  
+     "_software.name"  XPREP                           "data reduction"  
+     "_software.name"  XSCALE                          "data scaling"  
+     "_software.name"  XTALVIEW                        refinement  
+     "_software.name"  Xtrapol8                        "refinement,data scaling"  
+     "_software.name"  Zanuda                          "data reduction"  
    #
 save_
 #
@@ -63676,9 +64102,6 @@ save__pdbx_database_related.db_id
    _pdbx_item.name            "_pdbx_database_related.db_id"
    _pdbx_item.mandatory_code  no
    #
-   _pdbx_item_type.name  "_pdbx_database_related.db_id"
-   _pdbx_item_type.code  pdnx_related_db_code
-   #
    _pdbx_item_description.name         "_pdbx_database_related.db_id"
    _pdbx_item_description.description  "The identifying code in the related database"
    #
@@ -64834,6 +65257,9 @@ save__diffrn_radiation.pdbx_wavelength_list
    #
    _item_type.code  line
    #
+   _pdbx_item_type.name  "_diffrn_radiation.pdbx_wavelength_list"
+   _pdbx_item_type.code  pdbx_wavelength_list
+   #
 save_
 #
 save__diffrn_radiation.pdbx_wavelength
@@ -64865,6 +65291,9 @@ save__diffrn_source.pdbx_wavelength_list
    _pdbx_item_examples.name    "_diffrn_source.pdbx_wavelength_list"
    _pdbx_item_examples.case    "0.987 or 0.987, 0.988, 1.0 or 0.99-1.5"
    _pdbx_item_examples.detail  .
+   #
+   _pdbx_item_type.name  "_diffrn_source.pdbx_wavelength_list"
+   _pdbx_item_type.code  pdbx_wavelength_list
    #
    _item_aliases.alias_name  "_diffrn_source.rcsb_wavelength_list"
    _item_aliases.dictionary  cif_rcsb.dic
@@ -65022,6 +65451,7 @@ save__diffrn_source.pdbx_synchrotron_beamline
      "_diffrn_source.pdbx_synchrotron_beamline"  BL03            .  
      "_diffrn_source.pdbx_synchrotron_beamline"  BL03HB          .  
      "_diffrn_source.pdbx_synchrotron_beamline"  BL07            .  
+     "_diffrn_source.pdbx_synchrotron_beamline"  "BL09U MX-ES"   .  
      "_diffrn_source.pdbx_synchrotron_beamline"  BL-03           .  
      "_diffrn_source.pdbx_synchrotron_beamline"  BL10U2          .  
      "_diffrn_source.pdbx_synchrotron_beamline"  BL11-1          .  
@@ -65121,6 +65551,7 @@ save__diffrn_source.pdbx_synchrotron_beamline
      "_diffrn_source.pdbx_synchrotron_beamline"  I911-3          .  
      "_diffrn_source.pdbx_synchrotron_beamline"  I911-4          .  
      "_diffrn_source.pdbx_synchrotron_beamline"  I911-5          .  
+     "_diffrn_source.pdbx_synchrotron_beamline"  ID02U1A         .  
      "_diffrn_source.pdbx_synchrotron_beamline"  ID09            .  
      "_diffrn_source.pdbx_synchrotron_beamline"  ID13            .  
      "_diffrn_source.pdbx_synchrotron_beamline"  ID14-1          .  
@@ -65147,6 +65578,7 @@ save__diffrn_source.pdbx_synchrotron_beamline
      "_diffrn_source.pdbx_synchrotron_beamline"  MicroMAX        .  
      "_diffrn_source.pdbx_synchrotron_beamline"  MX1             .  
      "_diffrn_source.pdbx_synchrotron_beamline"  MX2             .  
+     "_diffrn_source.pdbx_synchrotron_beamline"  MX3             .  
      "_diffrn_source.pdbx_synchrotron_beamline"  NCI             .  
      "_diffrn_source.pdbx_synchrotron_beamline"  "P09 HiPhaX"    .  
      "_diffrn_source.pdbx_synchrotron_beamline"  P11             .  
@@ -65193,6 +65625,7 @@ save__diffrn_source.pdbx_synchrotron_beamline
      "_diffrn_source.pdbx_synchrotron_beamline"  X8C             .  
      "_diffrn_source.pdbx_synchrotron_beamline"  X9A             .  
      "_diffrn_source.pdbx_synchrotron_beamline"  X9B             .  
+     "_diffrn_source.pdbx_synchrotron_beamline"  XAIRA           .  
      "_diffrn_source.pdbx_synchrotron_beamline"  XALOC           .  
      "_diffrn_source.pdbx_synchrotron_beamline"  XPP             .  
    #
@@ -65237,10 +65670,11 @@ save__diffrn_source.pdbx_synchrotron_site
      "_diffrn_source.pdbx_synchrotron_site"  ESRF                              .  
      "_diffrn_source.pdbx_synchrotron_site"  "European XFEL"                   .  
      "_diffrn_source.pdbx_synchrotron_site"  "FRM II"                          .  
-     "_diffrn_source.pdbx_synchrotron_site"  "KURCHATOV SNC"                   .  
+     "_diffrn_source.pdbx_synchrotron_site"  HEPS                              .  
      "_diffrn_source.pdbx_synchrotron_site"  "JPARC MLF"                       .  
      "_diffrn_source.pdbx_synchrotron_site"  JRR-3M                            .  
      "_diffrn_source.pdbx_synchrotron_site"  KCSRNT                            .  
+     "_diffrn_source.pdbx_synchrotron_site"  "KURCHATOV SNC"                   .  
      "_diffrn_source.pdbx_synchrotron_site"  ILL                               .  
      "_diffrn_source.pdbx_synchrotron_site"  ISIS                              .  
      "_diffrn_source.pdbx_synchrotron_site"  LANSCE                            .  
@@ -65275,6 +65709,7 @@ save__diffrn_source.pdbx_synchrotron_site
      "_diffrn_source.pdbx_synchrotron_site"  SSRF                              .  
      "_diffrn_source.pdbx_synchrotron_site"  SSRL                              .  
      "_diffrn_source.pdbx_synchrotron_site"  "SwissFEL ARAMIS"                 .  
+     "_diffrn_source.pdbx_synchrotron_site"  NanoTerasu                        .  
    #
 save_
 #
@@ -77358,7 +77793,7 @@ save__pdbx_nmr_force_constants.exptl_distance_term_units
    _item_enumeration.value
    _item_enumeration.detail
      kcal/mol/A**2  "kilocalories per mole per square angstrom"  
-     kJ/mol/nm**2   "kilojoules per mole per square nanometer"  
+     kJ/mol/nm**2   "kilojoules per mole per square nanometre"  
      other          "author added units"  
    #
    _item_aliases.alias_name  "_rcsb_nmr_force_constants.exptl_distance_term_units"
@@ -77452,7 +77887,7 @@ save__pdbx_nmr_force_constants.exptl_J_coupling_term_units
    _item_enumeration.value
    _item_enumeration.detail
      kcal/mol/Hz**2  "kilocalories per mole per square angstrom"  
-     kJ/mol/Hz**2    "kilojoules per mole per square nanometer"  
+     kJ/mol/Hz**2    "kilojoules per mole per square nanometre"  
      other           "author added units"  
    #
    _item_aliases.alias_name  "_rcsb_nmr_force_constants.exptl_J_coupling_term_units"
@@ -77694,7 +78129,7 @@ save__pdbx_nmr_force_constants.covalent_geom_bond_term_units
    _item_enumeration.value
    _item_enumeration.detail
      kcal/mol/A**2  "kilocalories per mole per square angstrom"  
-     kJ/mol/nm**2   "kilojoules per mole per square nanometer"  
+     kJ/mol/nm**2   "kilojoules per mole per square nanometre"  
      other          "author added units"  
    #
    _item_aliases.alias_name  "_rcsb_nmr_force_constants.covalent_geom_bond_term_units"
@@ -77864,7 +78299,7 @@ save__pdbx_nmr_force_constants.non-bonded_inter_van_der_Waals_term_units
    _item_enumeration.value
    _item_enumeration.detail
      kcal/mol/A**4  "kilocalories per mole per angstrom to the 4th power"  
-     kJ/mol/nm**4   "kilojoules per mole per nanometer to the 4th power"  
+     kJ/mol/nm**4   "kilojoules per mole per nanometre to the 4th power"  
      other          "author added units"  
    #
    _item_aliases.alias_name  "_rcsb_nmr_force_constants.non-bonded_inter_van_der_Waals_term_units"
@@ -77931,7 +78366,7 @@ save__pdbx_nmr_force_constants.non-bonded_inter_radius_of_gyration_term_units
    _item_enumeration.value
    _item_enumeration.detail
      "kcal/mol/ A**2"  "kilocalories per mole per square angstrom"  
-     "kJ/mol/ nm**4"   "kilojoules per mole per square nanometer"  
+     "kJ/mol/ nm**4"   "kilojoules per mole per square nanometre"  
      other             "author added units"  
    #
    _item_aliases.alias_name  "_rcsb_nmr_force_constants.non-bonded_inter_radius_of_gyration_term_units"
@@ -92197,7 +92632,13 @@ save__pdbx_re_refinement.details
 save_
 #
 save_pdbx_struct_assembly_prop
-   _category.description     "              Properties and features of structural assemblies."
+   _category.description     
+;              Properties and features of structural assemblies.
+               ABSA (A^2) is the "Total buried surface are [A^2}"
+               SSA (A^2) is the "Surface area for the complex [A^2]"
+               MORE is "Internal energy [kcal/mol]"
+;
+
    _category.id              pdbx_struct_assembly_prop
    _category.mandatory_code  no
    #
@@ -92239,7 +92680,13 @@ save__pdbx_struct_assembly_prop.biol_id
 save_
 #
 save__pdbx_struct_assembly_prop.type
-   _item_description.description  "             The property type for the assembly."
+   _item_description.description  
+;             The property type for the assembly.
+              ABSA (A^2) is the "Total buried surface area (A^2)"
+              SSA (A^2) is "Surface area for the complex (A^2)"
+              MORE is "Internal energy (kcal/mol)"
+;
+
    #
    _item.name            "_pdbx_struct_assembly_prop.type"
    _item.category_id     pdbx_struct_assembly_prop
@@ -93180,7 +93627,7 @@ save__reflns.pdbx_Rrim_I_all
    _item_type.code  float
    #
    _item_range.minimum  0.0
-   _item_range.maximum  5.0
+   _item_range.maximum  .
    #
    _pdbx_item_range.name     "_reflns.pdbx_Rrim_I_all"
    _pdbx_item_range.minimum  0.01
@@ -93225,8 +93672,8 @@ save__reflns_shell.pdbx_Rrim_I_all
    _item_range.maximum  .
    #
    _pdbx_item_range.name     "_reflns_shell.pdbx_Rrim_I_all"
-   _pdbx_item_range.minimum  0.01
-   _pdbx_item_range.maximum  1.0
+   _pdbx_item_range.minimum  0.0
+   _pdbx_item_range.maximum  7.203
    #
 save_
 #
@@ -96718,6 +97165,7 @@ save__pdbx_chem_comp_audit.action_type
      "Modify synonyms"                .  
      "Modify linking type"            .  
      "Modify internal type"           .  
+     "Modify metal description"       .  
      "Modify parent residue"          .  
      "Modify processing site"         .  
      "Modify subcomponent list"       .  
@@ -115678,7 +116126,7 @@ save__pdbx_related_exp_data_set.data_set_type
    _pdbx_item_enumeration.detail
      "_pdbx_related_exp_data_set.data_set_type"  "diffraction image data"         .  
      "_pdbx_related_exp_data_set.data_set_type"  "small-angle scattering data"    .  
-     "_pdbx_related_exp_data_set.data_set_type"  EMPIAR                           .  
+     "_pdbx_related_exp_data_set.data_set_type"  "raw EM image data"              .  
      "_pdbx_related_exp_data_set.data_set_type"  "NMR free induction decay data"  .  
      "_pdbx_related_exp_data_set.data_set_type"  "other data"                     .  
    #
@@ -115699,6 +116147,42 @@ save__pdbx_related_exp_data_set.details
    #
    _pdbx_item.name            "_pdbx_related_exp_data_set.details"
    _pdbx_item.mandatory_code  no
+   #
+save_
+#
+save__pdbx_related_exp_data_set.db_source
+   _item_description.description  "        For external sources, the name of the resource."
+   #
+   _item.name            "_pdbx_related_exp_data_set.db_source"
+   _item.category_id     pdbx_related_exp_data_set
+   _item.mandatory_code  no
+   #
+   _item_type.code  line
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     "Apollo - University of Cambridge Repository"                                .  
+     CXIDB                                                                        .  
+     "DRYAD Database"                                                             .  
+     EMPIAR                                                                       .  
+     "ESRF Data Portal"                                                           .  
+     "ETH Zurich Research Collection"                                             .  
+     Etsin                                                                        .  
+     "Integrated Resource for Reproducibility in Macromolecular Crystallography"  .  
+     "International Union of Crystallography"                                     .  
+     "KAUST Repository"                                                           .  
+     "Keele Data Repository"                                                      .  
+     "Manchester eScholar Services"                                               .  
+     "MAXIV Public Data Repository"                                               .  
+     "Mendeley Data"                                                              .  
+     "MX-RDR (Macromolecular Xtallography Raw Data Repository)"                   .  
+     ProteinDiffraction                                                           .  
+     "PSI Public Data Repository"                                                 .  
+     "RMIT University Figshare"                                                   .  
+     "SBGrid Data Bank"                                                           .  
+     "Xtal Raw Data Archive"                                                      .  
+     Zenodo                                                                       .  
    #
 save_
 #
@@ -117784,13 +118268,17 @@ save__em_sample_support.grid_type
      "_em_sample_support.grid_type"  "PELCO Ultrathin Carbon with Lacey Carbon"  .  
      "_em_sample_support.grid_type"  Quantifoil                                  .  
      "_em_sample_support.grid_type"  "Quantifoil R0.6/1"                         .  
+     "_em_sample_support.grid_type"  "Quantifoil R1/1"                           .  
+     "_em_sample_support.grid_type"  "Quantifoil R1/2"                           .  
      "_em_sample_support.grid_type"  "Quantifoil R1/4"                           .  
      "_em_sample_support.grid_type"  "Quantifoil R2/1"                           .  
      "_em_sample_support.grid_type"  "Quantifoil R2/2"                           .  
      "_em_sample_support.grid_type"  "Quantifoil R2/4"                           .  
      "_em_sample_support.grid_type"  "Quantifoil R3/3"                           .  
+     "_em_sample_support.grid_type"  "Quantifoil R3/5"                           .  
      "_em_sample_support.grid_type"  "Quantifoil R3.5/1"                         .  
      "_em_sample_support.grid_type"  "Quantifoil R1.2/1.3"                       .  
+     "_em_sample_support.grid_type"  "Quantifoil R1.2/20"                        .  
      "_em_sample_support.grid_type"  "Quantifoil Active R2/1"                    .  
      "_em_sample_support.grid_type"  "Quantifoil Active R1.6/0.9"                .  
      "_em_sample_support.grid_type"  "Quantifoil Active R1.2/0.8"                .  
@@ -117805,8 +118293,13 @@ save__em_sample_support.grid_type
      "_em_sample_support.grid_type"  C-flat-2/1                                  .  
      "_em_sample_support.grid_type"  C-flat-1/1                                  .  
      "_em_sample_support.grid_type"  C-flat-2/2                                  .  
+     "_em_sample_support.grid_type"  "EMS Formvar Carbon"                        .  
      "_em_sample_support.grid_type"  "EMS Lacey Carbon"                          .  
      "_em_sample_support.grid_type"  "SPT Labtech self-wicking R1.2/0.8"         .  
+     "_em_sample_support.grid_type"  "ANTcryo ANTA Au300 R1.2/1.3"               .  
+     "_em_sample_support.grid_type"  "ANTcryo ANTA Cu300 R1.2/1.3"               .  
+     "_em_sample_support.grid_type"  "ANTcryo ANTA Au400 R1.2/1.3"               .  
+     "_em_sample_support.grid_type"  "ANTcryo ANTA Au300 R2.0/1.0"               .  
      "_em_sample_support.grid_type"  Homemade                                    .  
    #
 save_
@@ -118542,6 +119035,9 @@ save__em_imaging.microscope_model
      "_em_imaging.microscope_model"  "JEOL 4000EX"                  .  
      "_em_imaging.microscope_model"  "JEOL CRYO ARM 200"            .  
      "_em_imaging.microscope_model"  "JEOL CRYO ARM 300"            .  
+     "_em_imaging.microscope_model"  "SHUIMU TOTEM 120S"            .  
+     "_em_imaging.microscope_model"  "SHUIMU TOTEM 200S"            .  
+     "_em_imaging.microscope_model"  "SHUIMU TOTEM 300S"            .  
      "_em_imaging.microscope_model"  "SIEMENS SULEIKA"              .  
      "_em_imaging.microscope_model"  "TFS GLACIOS"                  .  
      "_em_imaging.microscope_model"  "TFS KRIOS"                    .  
@@ -118621,6 +119117,9 @@ save__em_imaging.microscope_model
      "_em_imaging.microscope_model"  "JEOL 4000EX"                  .  
      "_em_imaging.microscope_model"  "JEOL CRYO ARM 200"            .  
      "_em_imaging.microscope_model"  "JEOL CRYO ARM 300"            .  
+     "_em_imaging.microscope_model"  "SHUIMU TOTEM 120S"            .  
+     "_em_imaging.microscope_model"  "SHUIMU TOTEM 200S"            .  
+     "_em_imaging.microscope_model"  "SHUIMU TOTEM 300S"            .  
      "_em_imaging.microscope_model"  "SIEMENS SULEIKA"              .  
      "_em_imaging.microscope_model"  "TFS GLACIOS"                  .  
      "_em_imaging.microscope_model"  "TFS KRIOS"                    .  
@@ -118819,7 +119318,7 @@ save_
 #
 save__em_imaging.nominal_defocus_min
    _item_description.description  
-;   The minimum defocus value of the objective lens (in nanometers) used
+;   The minimum defocus value of the objective lens (in nanometres) used
     to obtain the recorded images. Negative values refer to overfocus.
 ;
 
@@ -118833,7 +119332,7 @@ save__em_imaging.nominal_defocus_min
    _pdbx_item_type.name  "_em_imaging.nominal_defocus_min"
    _pdbx_item_type.code  int
    #
-   _item_units.code  nanometers
+   _item_units.code  nanometres
    #
    _item_examples.case  1200
    #
@@ -118845,7 +119344,7 @@ save_
 #
 save__em_imaging.nominal_defocus_max
    _item_description.description  
-;   The maximum defocus value of the objective lens (in nanometers) used
+;   The maximum defocus value of the objective lens (in nanometres) used
     to obtain the recorded images. Negative values refer to overfocus.
 ;
 
@@ -118859,7 +119358,7 @@ save__em_imaging.nominal_defocus_max
    _pdbx_item_type.name  "_em_imaging.nominal_defocus_max"
    _pdbx_item_type.code  int
    #
-   _item_units.code  nanometers
+   _item_units.code  nanometres
    #
    _item_examples.case  5000
    #
@@ -118871,7 +119370,7 @@ save_
 #
 save__em_imaging.calibrated_defocus_min
    _item_description.description  
-;   The minimum calibrated defocus value of the objective lens (in nanometers) used
+;   The minimum calibrated defocus value of the objective lens (in nanometres) used
     to obtain the recorded images. Negative values refer to overfocus.
 ;
 
@@ -118882,7 +119381,7 @@ save__em_imaging.calibrated_defocus_min
    #
    _item_type.code  float
    #
-   _item_units.code  nanometers
+   _item_units.code  nanometres
    #
    _item_examples.case  1200
    #
@@ -118894,7 +119393,7 @@ save_
 #
 save__em_imaging.calibrated_defocus_max
    _item_description.description  
-;   The maximum calibrated defocus value of the objective lens (in nanometers) used
+;   The maximum calibrated defocus value of the objective lens (in nanometres) used
     to obtain the recorded images. Negative values refer to overfocus.
 ;
 
@@ -118905,7 +119404,7 @@ save__em_imaging.calibrated_defocus_max
    #
    _item_type.code  float
    #
-   _item_units.code  nanometers
+   _item_units.code  nanometres
    #
    _item_examples.case  5000
    #
@@ -123324,7 +123823,7 @@ save__em_focused_ion_beam.final_thickness
    _item.category_id     em_focused_ion_beam
    _item.mandatory_code  yes
    #
-   _item_units.code  nanometers
+   _item_units.code  nanometres
    #
    _item_type.code  positive_int
    #
@@ -123356,7 +123855,7 @@ save__em_focused_ion_beam.initial_thickness
    _item.category_id     em_focused_ion_beam
    _item.mandatory_code  yes
    #
-   _item_units.code  nanometers
+   _item_units.code  nanometres
    #
    _item_type.code  int
    #
@@ -123593,13 +124092,13 @@ save__em_ultramicrotomy.em_tomography_specimen_id
 save_
 #
 save__em_ultramicrotomy.final_thickness
-   _item_description.description  "  Final thickness of the sectioned sample, in nanometers"
+   _item_description.description  "  Final thickness of the sectioned sample, in nanometres"
    #
    _item.name            "_em_ultramicrotomy.final_thickness"
    _item.category_id     em_ultramicrotomy
    _item.mandatory_code  yes
    #
-   _item_units.code  nanometers
+   _item_units.code  nanometres
    #
    _item_type.code  positive_int
    #
@@ -124300,6 +124799,7 @@ save__em_support_film.material
      GRAPHENE  
      "GRAPHENE OXIDE"  
      "SILICON DIOXIDE"  
+     "NICKEL TITANIUM"  
    #
 save_
 #
@@ -125358,6 +125858,7 @@ save__em_image_recording.film_or_detector_model
      "_em_image_recording.film_or_detector_model"  "PROSCAN TEM-PIV (2k x 2k)"          .  
      "_em_image_recording.film_or_detector_model"  "SIA 15C (3k x 3k)"                  .  
      "_em_image_recording.film_or_detector_model"  "TFS FALCON 4i (4k x 4k)"            .  
+     "_em_image_recording.film_or_detector_model"  "TFS FALCON C (2k x 2k)"             .  
      "_em_image_recording.film_or_detector_model"  "TVIPS TEMCAM-F816 (8k x 8k)"        .  
      "_em_image_recording.film_or_detector_model"  "TVIPS TEMCAM-F415 (4k x 4k)"        .  
      "_em_image_recording.film_or_detector_model"  "TVIPS TEMCAM-F416 (4k x 4k)"        .  
@@ -126158,6 +126659,7 @@ save__em_software.name
      "_em_software.name"  Amber                           .  
      "_em_software.name"  AmiraFPM                        .  
      "_em_software.name"  Appion                          .  
+     "_em_software.name"  AreTomo                         .  
      "_em_software.name"  ARP/wARP                        .  
      "_em_software.name"  ASTRA-TOOLBOX                   .  
      "_em_software.name"  Auto3DEM                        .  
@@ -126175,11 +126677,14 @@ save__em_software.name
      "_em_software.name"  crYOLO                          .  
      "_em_software.name"  cryoDRGN                        .  
      "_em_software.name"  cryoDRGN2                       .  
+     "_em_software.name"  CryoSMART                       .  
      "_em_software.name"  cryoSPARC                       .  
+     "_em_software.name"  CrystFEL                        .  
      "_em_software.name"  CTFFIND                         .  
      "_em_software.name"  ctfit                           .  
      "_em_software.name"  CTFPHASEFLIP                    .  
      "_em_software.name"  CTFTILT                         .  
+     "_em_software.name"  DataSMART                       .  
      "_em_software.name"  DE-IM                           .  
      "_em_software.name"  DeepEMhancer                    .  
      "_em_software.name"  DIALS                           .  
@@ -126199,6 +126704,7 @@ save__em_software.name
      "_em_software.name"  EMfit                           .  
      "_em_software.name"  EMReady                         .  
      "_em_software.name"  EPU                             .  
+     "_em_software.name"  EPU-D                           .  
      "_em_software.name"  ERRASER                         .  
      "_em_software.name"  eTasED                          .  
      "_em_software.name"  ETHAN                           .  
@@ -126212,6 +126718,7 @@ save__em_software.name
      "_em_software.name"  FREALIX                         .  
      "_em_software.name"  Gautomatch                      .  
      "_em_software.name"  Gctf                            .  
+     "_em_software.name"  GisSPA                          .  
      "_em_software.name"  Gorgon                          .  
      "_em_software.name"  HADDOCK                         .  
      "_em_software.name"  HARUSPEX                        .  
@@ -126240,6 +126747,8 @@ save__em_software.name
      "_em_software.name"  M                               .  
      "_em_software.name"  MATLAB                          .  
      "_em_software.name"  MDFF                            .  
+     "_em_software.name"  MemBrain                        .  
+     "_em_software.name"  ModelAngelo                     .  
      "_em_software.name"  MODELLER                        .  
      "_em_software.name"  MOLREP                          .  
      "_em_software.name"  MPSA                            .  
@@ -126280,6 +126789,7 @@ save__em_software.name
      "_em_software.name"  Signature                       .  
      "_em_software.name"  SIMPLE                          .  
      "_em_software.name"  Situs                           .  
+     "_em_software.name"  SmartScope                      .  
      "_em_software.name"  SPARX                           .  
      "_em_software.name"  SPHIRE                          .  
      "_em_software.name"  SPIDER                          .  
@@ -126294,6 +126804,7 @@ save__em_software.name
      "_em_software.name"  TOMO3D                          .  
      "_em_software.name"  TOMOCTF                         .  
      "_em_software.name"  TomoAlign                       .  
+     "_em_software.name"  TOMOMAN                         .  
      "_em_software.name"  Topaz                           .  
      "_em_software.name"  "UCSF Chimera"                  .  
      "_em_software.name"  "UCSF ChimeraX"                 .  
@@ -126301,6 +126812,7 @@ save__em_software.name
      "_em_software.name"  UCSFImage                       .  
      "_em_software.name"  UCSFImage4                      .  
      "_em_software.name"  URO                             .  
+     "_em_software.name"  Velox                           .  
      "_em_software.name"  VMD                             .  
      "_em_software.name"  Warp                            .  
      "_em_software.name"  X-PLOR                          .  
@@ -134250,6 +134762,7 @@ save_pdbx_data_processing_status
     'helix'               'skip'
     'solvent position'    'skip'
     'ssbond'              'skip'
+    'metal coordination'  'skip'
 ;
 
    #
@@ -134272,6 +134785,7 @@ save__pdbx_data_processing_status.task_name
      site  
      link  
      helix  
+     "metal coordination"  
      sheet  
      "solvent position"  
      ssbond  
@@ -134280,12 +134794,13 @@ save__pdbx_data_processing_status.task_name
    _pdbx_item_enumeration.name
    _pdbx_item_enumeration.value
    _pdbx_item_enumeration.detail
-     "_pdbx_data_processing_status.task_name"  link                .  
-     "_pdbx_data_processing_status.task_name"  site                .  
-     "_pdbx_data_processing_status.task_name"  helix               .  
-     "_pdbx_data_processing_status.task_name"  sheet               .  
-     "_pdbx_data_processing_status.task_name"  "solvent position"  .  
-     "_pdbx_data_processing_status.task_name"  ssbond              .  
+     "_pdbx_data_processing_status.task_name"  link                  .  
+     "_pdbx_data_processing_status.task_name"  site                  .  
+     "_pdbx_data_processing_status.task_name"  helix                 .  
+     "_pdbx_data_processing_status.task_name"  "metal coordination"  .  
+     "_pdbx_data_processing_status.task_name"  sheet                 .  
+     "_pdbx_data_processing_status.task_name"  "solvent position"    .  
+     "_pdbx_data_processing_status.task_name"  ssbond                .  
    #
 save_
 #
@@ -140306,11 +140821,8 @@ save__chem_comp.pdbx_comp_type
    loop_
    _item_enumeration.value
    _item_enumeration.detail
-     solvent                 .  
-     "organic ligand"        .  
-     "inorganic ligand"      .  
-     "organometalic ligand"  .  
-     "metal cation"          .  
+     "metal cation"             .  
+     "metal-containing ligand"  .  
    #
    _item_aliases.alias_name  "_chem_comp.ndb_comp_type"
    _item_aliases.dictionary  cif_rcsb.dic
@@ -168300,6 +168812,7 @@ save__pdbx_chem_comp_pcm.type
      Carboxylation                                      .  
      Carboxymethylation                                 .  
      cGMPylation                                        .  
+     CMPylation                                         .  
      Chlorination                                       .  
      Cholesterylation                                   .  
      Citrullination                                     .  
@@ -168472,6 +168985,7 @@ save__pdbx_chem_comp_pcm.category
      "Nucleotide monophosphate"        "Nucleotide monophosphate protein modifications"  
      "Terminal acetylation"            "Terminal acetylation protein modification"  
      "Terminal amidation"              "Terminal amidation protein modification"  
+     "Metal coordination"              "Metal coordination"  
    #
 save_
 #
@@ -169289,6 +169803,7 @@ save__pdbx_modification_feature.type
      Carboxylation                                      .  
      Carboxymethylation                                 .  
      cGMPylation                                        .  
+     CMPylation                                         .  
      Chlorination                                       .  
      Cholesterylation                                   .  
      Citrullination                                     .  
@@ -169464,6 +169979,2774 @@ save__pdbx_modification_feature.category
      "Nucleotide monophosphate"        "Nucleotide monophosphate protein modifications"  
      "Terminal acetylation"            "Terminal acetylation protein modification"  
      "Terminal amidation"              "Terminal amidation protein modification"  
+     "Metal coordination"              "Metal coordination"  
+   #
+save_
+#
+save_pdbx_nonpoly_feature
+   _category.description     
+;              Data items in the PDBX_NONPOLY_FEATURE category provide
+               a selected list of atom level features for the chemical component.
+;
+
+   _category.id              pdbx_nonpoly_feature
+   _category.mandatory_code  no
+   #
+   _category_key.name  "_pdbx_nonpoly_feature.ordinal"
+   #
+   loop_
+   _category_group.id
+     inclusive_group  
+     chem_comp_group  
+     pdbx_group       
+   #
+   _category_examples.detail  
+;
+    Example 1 - based on 1HIP
+;
+
+   _category_examples.case    
+;
+    loop_
+    _pdbx_nonpoly_feature.ordinal
+    _pdbx_nonpoly_feature.label_asym_id
+    _pdbx_nonpoly_feature.label_seq_id
+    _pdbx_nonpoly_feature.label_comp_id
+    _pdbx_nonpoly_feature.auth_asym_id
+    _pdbx_nonpoly_feature.auth_seq_id 
+    _pdbx_nonpoly_feature.auth_comp_id
+    _pdbx_nonpoly_feature.PDB_ins_code
+    _pdbx_nonpoly_feature.type
+    _pdbx_nonpoly_feature.value
+    _pdbx_nonpoly_feature.provenance   
+    1 B . SF4 A 86 SF4 ? 'Group charge' 2 Author
+;
+
+   #
+save_
+#
+save__pdbx_nonpoly_feature.ordinal
+   _item_description.description  "An ordinal index for this category"
+   #
+   _item.name            "_pdbx_nonpoly_feature.ordinal"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_feature.label_asym_id
+   _item_description.description  "              The identifier of the instance of the STRUCT_ASYM_ID to which this feature applies."
+   #
+   _item.name            "_pdbx_nonpoly_feature.label_asym_id"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature.label_asym_id"
+   _item_linked.parent_name  "_atom_site.label_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_feature.label_seq_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.label_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature.label_seq_id"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  no
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature.label_seq_id"
+   _item_linked.parent_name  "_atom_site.label_seq_id"
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_feature.label_comp_id
+   _item_description.description  
+;              This data item is a pointer to id in the CHEM_COMP
+               category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature.label_comp_id"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature.label_comp_id"
+   _item_linked.parent_name  "_atom_site.label_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_feature.auth_asym_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_asym_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature.auth_asym_id"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature.auth_asym_id"
+   _item_linked.parent_name  "_atom_site.auth_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_feature.auth_seq_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature.auth_seq_id"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_nonpoly_feature.auth_comp_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_comp_id in
+               the ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature.auth_comp_id"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature.auth_comp_id"
+   _item_linked.parent_name  "_atom_site.auth_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_feature.PDB_ins_code
+   _item_description.description  "              PDB insertion code."
+   #
+   _item.name            "_pdbx_nonpoly_feature.PDB_ins_code"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature.PDB_ins_code"
+   _item_linked.parent_name  "_atom_site.pdbx_PDB_ins_code"
+   #
+save_
+#
+save__pdbx_nonpoly_feature.type
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_feature.type"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+   _item_enumeration.value   "Group charge"
+   _item_enumeration.detail  ?
+   #
+save_
+#
+save__pdbx_nonpoly_feature.value
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_feature.value"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   loop_
+   _item_examples.case
+     4            
+     5            
+     tetrahedral  
+   #
+save_
+#
+save__pdbx_nonpoly_feature.provenance
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_feature.provenance"
+   _item.category_id     pdbx_nonpoly_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     PDB     ?  
+     Author  ?  
+   #
+save_
+#
+save_pdbx_nonpoly_atom_feature
+   _category.description     
+;              Data items in the PDBX_NONPOLY_ATOM_FEATURE category provide
+               a selected list of atom level features for the chemical component.
+;
+
+   _category.id              pdbx_nonpoly_atom_feature
+   _category.mandatory_code  no
+   #
+   _category_key.name  "_pdbx_nonpoly_atom_feature.ordinal"
+   #
+   loop_
+   _category_group.id
+     inclusive_group  
+     chem_comp_group  
+     pdbx_group       
+   #
+   _category_examples.detail  
+;
+    Example 1 - based on 1RPT
+;
+
+   _category_examples.case    
+;
+    loop_
+    _pdbx_nonpoly_atom_feature.ordinal
+    _pdbx_nonpoly_atom_feature.label_asym_id
+    _pdbx_nonpoly_atom_feature.label_seq_id
+    _pdbx_nonpoly_atom_feature.label_comp_id
+    _pdbx_nonpoly_atom_feature.label_atom_id
+    _pdbx_nonpoly_atom_feature.label_alt_id
+    _pdbx_nonpoly_atom_feature.auth_asym_id
+    _pdbx_nonpoly_atom_feature.auth_seq_id 
+    _pdbx_nonpoly_atom_feature.auth_comp_id
+    _pdbx_nonpoly_atom_feature.auth_atom_id
+    _pdbx_nonpoly_atom_feature.PDB_ins_code
+    _pdbx_nonpoly_atom_feature.type
+    _pdbx_nonpoly_atom_feature.value
+    _pdbx_nonpoly_atom_feature.provenance 
+    1 D . VO4 V ? A 343 VO4 V ? 'Oxidation state' 5 Author
+;
+
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.ordinal
+   _item_description.description  "An ordinal index for this category"
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.ordinal"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.label_asym_id
+   _item_description.description  "              The identifier of the instance of the STRUCT_ASYM_ID to which this feature applies."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.label_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature.label_asym_id"
+   _item_linked.parent_name  "_atom_site.label_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.label_seq_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.label_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.label_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  no
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature.label_seq_id"
+   _item_linked.parent_name  "_atom_site.label_seq_id"
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.label_comp_id
+   _item_description.description  
+;              This data item is a pointer to id in the CHEM_COMP
+               category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.label_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature.label_comp_id"
+   _item_linked.parent_name  "_atom_site.label_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.label_atom_id
+   _item_description.description  "              The identifier for the target atom to which the feature is assigned."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.label_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature.label_atom_id"
+   _item_linked.parent_name  "_atom_site.label_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.label_alt_id
+   _item_description.description  "              A place holder to indicate alternate conformation."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.label_alt_id"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature.label_alt_id"
+   _item_linked.parent_name  "_atom_site.label_alt_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.auth_asym_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_asym_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.auth_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature.auth_asym_id"
+   _item_linked.parent_name  "_atom_site.auth_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.auth_seq_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.auth_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.auth_comp_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_comp_id in
+               the ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.auth_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature.auth_comp_id"
+   _item_linked.parent_name  "_atom_site.auth_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.auth_atom_id
+   _item_description.description  
+;              A component of the identifier for partner 1 of the structure
+               connection.
+
+               This data item is a pointer to _atom_site.auth_atom_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.auth_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature.auth_atom_id"
+   _item_linked.parent_name  "_atom_site.auth_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.PDB_ins_code
+   _item_description.description  "              PDB insertion code."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.PDB_ins_code"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature.PDB_ins_code"
+   _item_linked.parent_name  "_atom_site.pdbx_PDB_ins_code"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.type
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.type"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+   _item_enumeration.value   "Oxidation state"
+   _item_enumeration.detail  ?
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.value
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.value"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+   loop_
+   _item_examples.case
+     4            
+     5            
+     tetrahedral  
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature.provenance
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature.provenance"
+   _item.category_id     pdbx_nonpoly_atom_feature
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     PDB     ?  
+     Author  ?  
+   #
+save_
+#
+save_pdbx_nonpoly_atom_feature_evidence
+   _category.description     
+;              Data items in the PDBX_NONPOLY_ATOM_FEATURE_EVIDENCE category provide
+               a selected list of atom level features for the chemical component.
+;
+
+   _category.id              pdbx_nonpoly_atom_feature_evidence
+   _category.mandatory_code  no
+   #
+   _category_key.name  "_pdbx_nonpoly_atom_feature_evidence.ordinal"
+   #
+   loop_
+   _category_group.id
+     inclusive_group  
+     chem_comp_group  
+     pdbx_group       
+   #
+   _category_examples.detail  
+;
+    Example 1 - based on 1RPT
+;
+
+   _category_examples.case    
+;
+    loop_
+    _pdbx_nonpoly_atom_feature_evidence.ordinal
+    _pdbx_nonpoly_atom_feature_evidence.label_asym_id
+    _pdbx_nonpoly_atom_feature_evidence.label_seq_id
+    _pdbx_nonpoly_atom_feature_evidence.label_comp_id
+    _pdbx_nonpoly_atom_feature_evidence.label_atom_id
+    _pdbx_nonpoly_atom_feature_evidence.label_alt_id
+    _pdbx_nonpoly_atom_feature_evidence.auth_asym_id
+    _pdbx_nonpoly_atom_feature_evidence.auth_seq_id 
+    _pdbx_nonpoly_atom_feature_evidence.auth_comp_id
+    _pdbx_nonpoly_atom_feature_evidence.auth_atom_id
+    _pdbx_nonpoly_atom_feature_evidence.PDB_ins_code
+    _pdbx_nonpoly_atom_feature_evidence.type
+    _pdbx_nonpoly_atom_feature_evidence.experimental_support
+    _pdbx_nonpoly_atom_feature_evidence.details
+    1 D . VO4 V ? A 343 VO4 V ? 'Metal identity' 'Anomalous scattering' ?
+    1 D . VO4 V ? A 343 VO4 V ? 'Oxidation state' 'UV-Vis spectroscopy' ?
+;
+
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.ordinal
+   _item_description.description  "An ordinal index for this category"
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.ordinal"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.label_asym_id
+   _item_description.description  "              The identifier of the instance of the STRUCT_ASYM_ID to which this feature applies."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.label_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature_evidence.label_asym_id"
+   _item_linked.parent_name  "_atom_site.label_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.label_seq_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.label_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.label_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature_evidence.label_seq_id"
+   _item_linked.parent_name  "_atom_site.label_seq_id"
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.label_comp_id
+   _item_description.description  
+;              This data item is a pointer to id in the ATOM_SITE
+               category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.label_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature_evidence.label_comp_id"
+   _item_linked.parent_name  "_atom_site.label_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.label_atom_id
+   _item_description.description  "              The identifier for the target atom to which the feature is assigned."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.label_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature_evidence.label_atom_id"
+   _item_linked.parent_name  "_atom_site.label_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.label_alt_id
+   _item_description.description  "              A place holder to indicate alternate conformation."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.label_alt_id"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature_evidence.label_alt_id"
+   _item_linked.parent_name  "_atom_site.label_alt_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.auth_asym_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_asym_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.auth_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature_evidence.auth_asym_id"
+   _item_linked.parent_name  "_atom_site.auth_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.auth_seq_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.auth_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.auth_comp_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_comp_id in
+               the ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.auth_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature_evidence.auth_comp_id"
+   _item_linked.parent_name  "_atom_site.auth_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.auth_atom_id
+   _item_description.description  
+;              A component of the identifier for partner 1 of the structure
+               connection.
+
+               This data item is a pointer to _atom_site.auth_atom_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.auth_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature_evidence.auth_atom_id"
+   _item_linked.parent_name  "_atom_site.auth_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.PDB_ins_code
+   _item_description.description  "              PDB insertion code."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.PDB_ins_code"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_feature_evidence.PDB_ins_code"
+   _item_linked.parent_name  "_atom_site.pdbx_PDB_ins_code"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.type
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.type"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     "Oxidation state"  ?  
+     "Metal identity"   ?  
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.experimental_support
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.experimental_support"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+   _item_examples.case  "Inductively coupled plasma mass spectrometry"
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     "Anomalous scattering"                          ?  
+     "Inductively coupled plasma mass spectrometry"  ?  
+     "Infrared spectroscopy"                         ?  
+     "Electron paramagnetic resonance spectroscopy"  ?  
+     "Mossbauer spectroscopy"                        ?  
+     "Raman spectroscopy"                            ?  
+     "UV-Vis spectroscopy"                           ?  
+     "X-ray absorption spectroscopy"                 ?  
+     "X-ray fluorescence"                            ?  
+     Other                                           ?  
+   #
+save_
+#
+save__pdbx_nonpoly_atom_feature_evidence.details
+   _item_description.description  "              Additional details on this atom assignment"
+   #
+   _item.name            "_pdbx_nonpoly_atom_feature_evidence.details"
+   _item.category_id     pdbx_nonpoly_atom_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  line
+   #
+save_
+#
+save_pdbx_nonpoly_feature_evidence
+   _category.description     
+;              Data items in the PDBX_NONPOLY_FEATURE_EVIDENCE category provide
+               a selected list of asym level features for the chemical component.
+;
+
+   _category.id              pdbx_nonpoly_feature_evidence
+   _category.mandatory_code  no
+   #
+   _category_key.name  "_pdbx_nonpoly_feature_evidence.ordinal"
+   #
+   loop_
+   _category_group.id
+     inclusive_group  
+     chem_comp_group  
+     pdbx_group       
+   #
+   _category_examples.detail  
+;
+    Example 1 -
+;
+
+   _category_examples.case    
+;
+    loop_
+    _pdbx_nonpoly_feature_evidence.ordinal
+    _pdbx_nonpoly_feature_evidence.label_asym_id
+    _pdbx_nonpoly_feature_evidence.label_seq_id
+    _pdbx_nonpoly_feature_evidence.label_comp_id
+    _pdbx_nonpoly_feature_evidence.auth_asym_id
+    _pdbx_nonpoly_feature_evidence.auth_seq_id 
+    _pdbx_nonpoly_feature_evidence.auth_comp_id
+    _pdbx_nonpoly_feature_evidence.PDB_ins_code
+    _pdbx_nonpoly_feature_evidence.type
+    _pdbx_nonpoly_feature_evidence.experimental_support
+    _pdbx_nonpoly_feature_evidence.details
+    1 B . SF4 A 86 SF4 ? 'Group charge' 'Electron paramagnetic resonance spectrometry' ?
+;
+
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.ordinal
+   _item_description.description  "An ordinal index for this category"
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.ordinal"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.label_asym_id
+   _item_description.description  "              The identifier of the instance of the STRUCT_ASYM_ID to which this feature applies."
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.label_asym_id"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature_evidence.label_asym_id"
+   _item_linked.parent_name  "_atom_site.label_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.label_seq_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.label_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.label_seq_id"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature_evidence.label_seq_id"
+   _item_linked.parent_name  "_atom_site.label_seq_id"
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.label_comp_id
+   _item_description.description  
+;              This data item is a pointer to id in the CHEM_COMP
+               category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.label_comp_id"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature_evidence.label_comp_id"
+   _item_linked.parent_name  "_atom_site.label_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.auth_asym_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_asym_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.auth_asym_id"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature_evidence.auth_asym_id"
+   _item_linked.parent_name  "_atom_site.auth_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.auth_seq_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.auth_seq_id"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.auth_comp_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_comp_id in
+               the ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.auth_comp_id"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature_evidence.auth_comp_id"
+   _item_linked.parent_name  "_atom_site.auth_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.PDB_ins_code
+   _item_description.description  "              PDB insertion code."
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.PDB_ins_code"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_feature_evidence.PDB_ins_code"
+   _item_linked.parent_name  "_atom_site.pdbx_PDB_ins_code"
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.type
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.type"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+   _item_enumeration.value   "Group charge"
+   _item_enumeration.detail  ?
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.experimental_support
+   _item_description.description  "              The feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.experimental_support"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+   _item_examples.case  "Inductively coupled plasma mass spectrometry"
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     "Electron paramagnetic resonance spectroscopy"  ?  
+     "Mossbauer spectroscopy"                        ?  
+     "UV-Vis spectroscopy"                           ?  
+     Other                                           ?  
+   #
+save_
+#
+save__pdbx_nonpoly_feature_evidence.details
+   _item_description.description  "              Additional details on this atom assignment"
+   #
+   _item.name            "_pdbx_nonpoly_feature_evidence.details"
+   _item.category_id     pdbx_nonpoly_feature_evidence
+   _item.mandatory_code  no
+   #
+   _item_type.code  line
+   #
+save_
+#
+save_pdbx_chem_comp_atom_coordination
+   _category.description     
+;             Data items in the PDBX_CHEM_COMP_ATOM_COORDINATION category provide
+              coordination information on selected atoms
+;
+
+   _category.id              pdbx_chem_comp_atom_coordination
+   _category.mandatory_code  no
+   #
+   loop_
+   _category_key.name
+     "_pdbx_chem_comp_atom_coordination.geometry_id"  
+     "_pdbx_chem_comp_atom_coordination.provenance"  
+   #
+   loop_
+   _category_group.id
+     inclusive_group  
+     chem_comp_group  
+     pdbx_group       
+   #
+   loop_
+   _category_examples.detail
+   _category_examples.case
+     
+;
+    Example 1 -
+;
+  
+;
+    loop_
+    _pdbx_chem_comp_atom_coordination.geometry_id
+    _pdbx_chem_comp_atom_coordination.comp_id
+    _pdbx_chem_comp_atom_coordination.atom_id
+    _pdbx_chem_comp_atom_coordination.number
+    _pdbx_chem_comp_atom_coordination.geometry_calculated
+    _pdbx_chem_comp_atom_coordination.geometry_generic
+    _pdbx_chem_comp_atom_coordination.provenance
+    _pdbx_chem_comp_atom_coordination.geometry_abbr
+    _pdbx_chem_comp_atom_coordination.representative_entry_id
+    1 VO4 V 4 tetrahedron           tetrahedral             FindGeo     TET  1VNH
+    1 VO4 V 4 tetrahedral           tetrahedral             MetalCoord  TET  1VNH
+    2 VO4 V 5 'trigonal bipyramid' 'trigonal bipyramidal'   FindGeo     TBP  1RPT
+    2 VO4 V 5 trigonal-bipyramid   'trigonal bipyramidal'   MetalCoord  TBP  1RPT
+;
+  
+     
+;
+    Example 2 -
+;
+  
+;
+    loop_
+    _pdbx_chem_comp_atom_coordination.geometry_id
+    _pdbx_chem_comp_atom_coordination.comp_id
+    _pdbx_chem_comp_atom_coordination.atom_id
+    _pdbx_chem_comp_atom_coordination.number
+    _pdbx_chem_comp_atom_coordination.geometry_calculated
+    _pdbx_chem_comp_atom_coordination.geometry_generic
+    _pdbx_chem_comp_atom_coordination.provenance
+    _pdbx_chem_comp_atom_coordination.geometry_abbr
+    _pdbx_chem_comp_atom_coordination.representative_entry_id
+    1 SF4 FE1 4 tetrahedron tetrahedral FindGeo    TET  7NPA    
+    1 SF4 FE1 4 tetrahedral tetrahedral MetalCoord TET  2C42 
+    2 SF4 FE2 4 tetrahedron tetrahedral FindGeo    TET  7NPA    
+    2 SF4 FE2 4 tetrahedral tetrahedral MetalCoord TET  8RIU 
+    3 SF4 FE3 4 tetrahedron tetrahedral FindGeo    TET  1GTE    
+    3 SF4 FE3 4 tetrahedral tetrahedral MetalCoord TET  7NPA  
+    4 SF4 FE4 4 tetrahedron tetrahedral FindGeo    TET  2FD2    
+    4 SF4 FE4 4 tetrahedral tetrahedral MetalCoord TET  2FD2
+;
+  
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination.geometry_id
+   _item_description.description  
+;    This data item is used to group together equivalent geometries coming from different
+     software programs. For instance, if one program has an output of 'tetrahedral' and
+     another has an output of 'tetrahedron' for the same atom, these two records will
+     have the same geometry_id because these two outputs represent the same coordination geometry.
+;
+
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination.geometry_id"
+   _item.category_id     pdbx_chem_comp_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination.comp_id
+   _item_description.description  
+;              This data item is a pointer to _chem_comp_atom.comp_id in the CHEM_COMP
+               category.
+;
+
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination.comp_id"
+   _item.category_id     pdbx_chem_comp_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_linked.child_name   "_pdbx_chem_comp_atom_coordination.comp_id"
+   _item_linked.parent_name  "_chem_comp_atom.comp_id"
+   #
+   _item_type.code  ucode
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination.atom_id
+   _item_description.description  "              The identifier for the target atom to which the feature is assigned."
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination.atom_id"
+   _item.category_id     pdbx_chem_comp_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_chem_comp_atom_coordination.atom_id"
+   _item_linked.parent_name  "_chem_comp_atom.atom_id"
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination.number
+   _item_description.description  "              The coordination number of the target atom."
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination.number"
+   _item.category_id     pdbx_chem_comp_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   loop_
+   _item_range.maximum
+   _item_range.minimum
+     24  24  
+     24   2  
+      2   2  
+   #
+   loop_
+   _pdbx_item_range.maximum
+   _pdbx_item_range.minimum
+     10  10  
+     10   2  
+      2   2  
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination.geometry_calculated
+   _item_description.description  
+;              This data item contains the geometry output from a software program (for example, FindGeo or MetalCoord).
+               The geometry derived from observed geometries in atomic coordinate files.
+;
+
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination.geometry_calculated"
+   _item.category_id     pdbx_chem_comp_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination.geometry_generic
+   _item_description.description  
+;              This data item translates the geometry output from a software program (for example, FindGeo or MetalCoord) into
+               a unified naming scheme. As software programs sometimes have different names for the same geometry (for instance,
+	       'tetrahedral' and 'tetrahedron' correspond to the same geometry), this data item provides a name for
+	       the geometry that is consistent regardless of the provenance to enhance findability. The geometry derived
+	       from observed geometries in atomic coordinate files.
+;
+
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination.geometry_generic"
+   _item.category_id     pdbx_chem_comp_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     linear                                        ?  
+     bent                                          ?  
+     "trigonal planar"                             ?  
+     pyramidal                                     ?  
+     "t shape"                                     ?  
+     "linear monocapped"                           ?  
+     tetrahedral                                   ?  
+     "square planar"                               ?  
+     "trigonal pyramidal"                          ?  
+     "trigonal bipyramidal with vacancy"           ?  
+     "square pyramidal with vacancy"               ?  
+     "trigonal planar monocapped"                  ?  
+     "linear bicapped"                             ?  
+     "square non-planar"                           ?  
+     "square pyramidal"                            ?  
+     "trigonal bipyramidal"                        ?  
+     "trigonal prismatic with vacancy"             ?  
+     "square planar monocapped"                    ?  
+     "trigonal planar bicapped"                    ?  
+     "trigonal planar tricapped"                   ?  
+     octahedral                                    ?  
+     "trigonal prismatic"                          ?  
+     "pentagonal bipyramidal with vacancy"         ?  
+     "octahedral monocapped with vacancy"          ?  
+     "trigonal prismatic monocapped with vacancy"  ?  
+     "sandwich 4h 2"                               ?  
+     "sandwich 4 2"                                ?  
+     "sandwich 5 1"                                ?  
+     "square planar bicapped"                      ?  
+     "hexagonal planar"                            ?  
+     "pentagonal bipyramidal"                      ?  
+     "trigonal prismatic monocapped"               ?  
+     "octahedral monocapped"                       ?  
+     "hexagonal bipyramidal with vacancy"          ?  
+     "cubic with vacancy"                          ?  
+     "square antiprismatic with vacancy"           ?  
+     "sandwich 6 1"                                ?  
+     "sandwich 4 3"                                ?  
+     "sandwich 4h 3"                               ?  
+     "sandwich 5 2"                                ?  
+     "hexagonal bipyramidal"                       ?  
+     cubic                                         ?  
+     "square antiprismatic"                        ?  
+     "octahedral bicapped"                         ?  
+     "trigonal prismatic bicapped"                 ?  
+     "sandwich 4h 4h"                              ?  
+     "sandwich 7 1"                                ?  
+     "sandwich 4h 4"                               ?  
+     "sandwich 5 capped 1"                         ?  
+     "sandwich 5 3"                                ?  
+     "sandwich 5h 3"                               ?  
+     "sandwich 6 2"                                ?  
+     dodecahedral                                  ?  
+     "trigonal prism tricapped"                    ?  
+     "square antiprismatic monocapped"             ?  
+     "sandwich 7 2"                                ?  
+     "sandwich 5 tricapped i"                      ?  
+     "sandwich 5 4h"                               ?  
+     "sandwich 5 4"                                ?  
+     "sandwich 6 3"                                ?  
+     "pentagonal prismatic"                        ?  
+     "square antiprismatic bicapped"               ?  
+     "sandwich 5 5o"                               ?  
+     "sandwich 6 trigonal pyramidal"               ?  
+     "sandwich 6 4"                                ?  
+     "sandwich 5 4 i"                              ?  
+     "pentagonal antiprismatic"                    ?  
+     "sandwich 7 3"                                ?  
+     "sandwich 5 tricapped v"                      ?  
+     "sandwich 5 square pyramidal"                 ?  
+     "sandwich 5 5"                                ?  
+     "sandwich 5 pentagonal pyramidal"             ?  
+     "trigonal prismatic all face capped"          ?  
+     "sandwich 5 square pyramidal monocapped"      ?  
+     "sandwich 8 3"                                ?  
+     "sandwich 5 4h v"                             ?  
+     "sandwich 5 5 i"                              ?  
+     "sandwich 6 5"                                ?  
+     seamine                                       ?  
+     cuboctahedral                                 ?  
+     "sandwich 5 hexagonal pyramidal"              ?  
+     "sandwich 8 4"                                ?  
+     "paired octahedral"                           ?  
+     "sandwich 7 5"                                ?  
+     "sandwich 6 6"                                ?  
+     "sandwich 5 5 v"                              ?  
+     "sandwich 6 5 v"                              ?  
+     "sandwich 8 5"                                ?  
+     "sandwich 5 5 v i"                            ?  
+     "sandwich 5 5 v v 3d"                         ?  
+     "sandwich 6 6 v"                              ?  
+     "sandwich c5 5 i"                             ?  
+     "sandwich 5 5 v v"                            ?  
+     "sandwich 8 5 i"                              ?  
+     "sandwich 5 5 4"                              ?  
+     "sandwich 6 6 triangle"                       ?  
+     "sandwich 5 5 star"                           ?  
+     "penta trigonal planar"                       ?  
+     "penta trigonal planar i"                     ?  
+     "sandwich 8 8"                                ?  
+     "penta trigonal planar v"                     ?  
+     "penta trigonal planar i i"                   ?  
+     "sandwich 8 8 i"                              ?  
+     "sandwich 8 8 v"                              ?  
+     ball                                          ?  
+     irregular                                     ?  
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination.geometry_abbr
+   _item_description.description  
+;              This data item lists the abbreviated name of the geometry, as specified in the
+               _pdbx_chem_comp_atom_coordination_sphere.descriptor. For instance, square planar
+	       is abbreviated to SPL. The geometry derived from observed geometries in atomic coordinate files.
+;
+
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination.geometry_abbr"
+   _item.category_id     pdbx_chem_comp_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination.provenance
+   _item_description.description  "              The provenance of the feature assigned to this atom."
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination.provenance"
+   _item.category_id     pdbx_chem_comp_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     PDB         ?  
+     FindGeo     ?  
+     MetalCoord  ?  
+     Author      ?  
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination.representative_entry_id
+   _item_description.description  "The representative entry for this set"
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination.representative_entry_id"
+   _item.category_id     pdbx_chem_comp_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  ucode
+   #
+   _pdbx_item_context.type       CHEM_COMP_INT
+   _pdbx_item_context.item_name  "_pdbx_chem_comp_atom_coordination.representative_entry_id"
+   #
+save_
+#
+save_pdbx_chem_comp_atom_coordination_sphere
+   _category.description     
+;             Data items in the PDBX_CHEM_COMP_ATOM_COORDINATION_SPHERE category provide
+              geometric coordination information on selected atoms
+;
+
+   _category.id              pdbx_chem_comp_atom_coordination_sphere
+   _category.mandatory_code  no
+   #
+   _category_key.name  "_pdbx_chem_comp_atom_coordination_sphere.id"
+   #
+   loop_
+   _category_group.id
+     inclusive_group  
+     chem_comp_group  
+     pdbx_group       
+   #
+   loop_
+   _category_examples.detail
+   _category_examples.case
+     
+;
+    Example 1 -
+;
+  
+;
+    loop_
+    _pdbx_chem_comp_atom_coordination_sphere.id
+    _pdbx_chem_comp_atom_coordination_sphere.geometry_id
+    _pdbx_chem_comp_atom_coordination_sphere.comp_id
+    _pdbx_chem_comp_atom_coordination_sphere.atom_id
+    _pdbx_chem_comp_atom_coordination_sphere.descriptor
+    _pdbx_chem_comp_atom_coordination_sphere.provenance
+    _pdbx_chem_comp_atom_coordination_sphere.representative_entry_id
+    1 1 VO4 V @TET{V,O,O,O,O}   MetalCoord  1VNH
+    2 2 VO4 V @TBP{V,N,O,O,O,O} MetalCoord  1RPT
+;
+  
+     
+;
+    Example 2 -
+;
+  
+;
+    loop_
+    _pdbx_chem_comp_atom_coordination_sphere.id
+    _pdbx_chem_comp_atom_coordination_sphere.geometry_id
+    _pdbx_chem_comp_atom_coordination_sphere.comp_id
+    _pdbx_chem_comp_atom_coordination_sphere.atom_id
+    _pdbx_chem_comp_atom_coordination_sphere.descriptor
+    _pdbx_chem_comp_atom_coordination_sphere.provenance
+    _pdbx_chem_comp_atom_coordination_sphere.representative_entry_id
+    1    1  SF4  FE1  @TET{Fe,S,S,S,S}   MetalCoord  2C42    
+    2    1  SF4  FE1  @TET{Fe,N,S,S,S}   MetalCoord  7LJT  
+    3    1  SF4  FE1  @TET{Fe,O,S,S,S}   MetalCoord  8VPO    
+    4    2  SF4  FE2  @TET{Fe,S,S,S,S}   MetalCoord  8RIU     
+    5    2  SF4  FE2  @TET{Fe,N,S,S,S}   MetalCoord  6Z7R 
+    6    2  SF4  FE2  @TET{Fe,O,S,S,S}   MetalCoord  8RIU     
+    7    2  SF4  FE2  @TET{Fe,S,S,S,Cl}  MetalCoord  8CP4 
+    8    3  SF4  FE3  @TET{Fe,S,S,S,S}   MetalCoord  7NPA    
+    9    3  SF4  FE3  @TET{Fe,N,S,S,S}   MetalCoord  6GAL 
+    10   3  SF4  FE3  @TET{Fe,O,S,S,S}   MetalCoord  7M31    
+    11   3  SF4  FE3  @TET{Fe,S,S,S,Cl}  MetalCoord  7P4M  
+    12   4  SF4  FE4  @TET{Fe,S,S,S,S}   MetalCoord  2FD2    
+    13   4  SF4  FE4  @TET{Fe,N,S,S,S}   MetalCoord  8POW 
+    14   4  SF4  FE4  @TET{Fe,O,S,S,S}   MetalCoord  5EXJ    
+    15   4  SF4  FE4  @TET{Fe,S,S,S,Cl}  MetalCoord  4S28
+;
+  
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination_sphere.id
+   _item_description.description  "An ordinal index for this category"
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination_sphere.id"
+   _item.category_id     pdbx_chem_comp_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination_sphere.geometry_id
+   _item_description.description  
+;    This data item is a foreign key to _pdbx_chem_comp_atom_coordination.geometry_id. This item maps the
+     coordination descriptor to a specific geometry described in the pdbx_chem_comp_atom_coordination category.
+;
+
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination_sphere.geometry_id"
+   _item.category_id     pdbx_chem_comp_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_linked.child_name   "_pdbx_chem_comp_atom_coordination_sphere.geometry_id"
+   _item_linked.parent_name  "_pdbx_chem_comp_atom_coordination.geometry_id"
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination_sphere.comp_id
+   _item_description.description  
+;              This data item is a pointer to _chem_comp_atom.comp_id in the CHEM_COMP
+               category.
+;
+
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination_sphere.comp_id"
+   _item.category_id     pdbx_chem_comp_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_linked.child_name   "_pdbx_chem_comp_atom_coordination_sphere.comp_id"
+   _item_linked.parent_name  "_chem_comp_atom.comp_id"
+   #
+   _item_type.code  ucode
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination_sphere.atom_id
+   _item_description.description  "              The identifier for the target atom to which the feature is assigned."
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination_sphere.atom_id"
+   _item.category_id     pdbx_chem_comp_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_chem_comp_atom_coordination_sphere.atom_id"
+   _item_linked.parent_name  "_chem_comp_atom.atom_id"
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination_sphere.descriptor
+   _item_description.description  
+;              This data item contains a descriptor of the coordination environment of
+               an atom. The descriptor is derived from observed coordination environments
+	       in atomic coordinate files.
+;
+
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination_sphere.descriptor"
+   _item.category_id     pdbx_chem_comp_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination_sphere.provenance
+   _item_description.description  "              The provenance of the feature assigned to this atom."
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination_sphere.provenance"
+   _item.category_id     pdbx_chem_comp_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     PDB         ?  
+     FindGeo     ?  
+     MetalCoord  ?  
+   #
+save_
+#
+save__pdbx_chem_comp_atom_coordination_sphere.representative_entry_id
+   _item_description.description  "The representative entry for this set"
+   #
+   _item.name            "_pdbx_chem_comp_atom_coordination_sphere.representative_entry_id"
+   _item.category_id     pdbx_chem_comp_atom_coordination_sphere
+   _item.mandatory_code  no
+   #
+   _item_type.code  ucode
+   #
+   _pdbx_item_context.type       CHEM_COMP_INT
+   _pdbx_item_context.item_name  "_pdbx_chem_comp_atom_coordination_sphere.representative_entry_id"
+   #
+save_
+#
+save_pdbx_nonpoly_atom_coordination
+   _category.description     
+;             Data items in the PDBX_NONPOLY_ATOM_COORDINATION category provide
+              coordination information on selected atoms
+;
+
+   _category.id              pdbx_nonpoly_atom_coordination
+   _category.mandatory_code  no
+   #
+   loop_
+   _category_key.name
+     "_pdbx_nonpoly_atom_coordination.geometry_id"  
+     "_pdbx_nonpoly_atom_coordination.provenance"  
+   #
+   loop_
+   _category_group.id
+     inclusive_group  
+     pdbx_group       
+   #
+   loop_
+   _category_examples.detail
+   _category_examples.case
+     
+;
+    Example 1 - based on 1RPT
+;
+  
+;
+    loop_
+    _pdbx_nonpoly_atom_coordination.geometry_id
+    _pdbx_nonpoly_atom_coordination.label_asym_id 
+    _pdbx_nonpoly_atom_coordination.label_seq_id
+    _pdbx_nonpoly_atom_coordination.label_comp_id
+    _pdbx_nonpoly_atom_coordination.label_atom_id
+    _pdbx_nonpoly_atom_coordination.label_alt_id
+    _pdbx_nonpoly_atom_coordination.auth_asym_id
+    _pdbx_nonpoly_atom_coordination.auth_seq_id
+    _pdbx_nonpoly_atom_coordination.auth_comp_id
+    _pdbx_nonpoly_atom_coordination.auth_atom_id
+    _pdbx_nonpoly_atom_coordination.PDB_ins_code
+    _pdbx_nonpoly_atom_coordination.number
+    _pdbx_nonpoly_atom_coordination.geometry_calculated
+    _pdbx_nonpoly_atom_coordination.software_remark
+    _pdbx_nonpoly_atom_coordination.geometry_generic
+    _pdbx_nonpoly_atom_coordination.geometry_abbr
+    _pdbx_nonpoly_atom_coordination.provenance
+    _pdbx_nonpoly_atom_coordination.assessment
+    1 D . VO4 V ? A 343 VO4 V ? 5 'trigonal bipyramid'  regular  'trigonal bipyramidal' .    FindGeo    Expected
+    1 D . VO4 V ? A 343 VO4 V ? 5 trigonal-bipyramid    .        'trigonal bipyramidal' TBP  MetalCoord Expected
+;
+  
+     
+;
+    Example 2 - based on 1HIP:
+;
+  
+;
+    loop_
+    _pdbx_nonpoly_atom_coordination.geometry_id
+    _pdbx_nonpoly_atom_coordination.label_asym_id 
+    _pdbx_nonpoly_atom_coordination.label_seq_id
+    _pdbx_nonpoly_atom_coordination.label_comp_id
+    _pdbx_nonpoly_atom_coordination.label_atom_id
+    _pdbx_nonpoly_atom_coordination.label_alt_id
+    _pdbx_nonpoly_atom_coordination.auth_asym_id
+    _pdbx_nonpoly_atom_coordination.auth_seq_id
+    _pdbx_nonpoly_atom_coordination.auth_comp_id
+    _pdbx_nonpoly_atom_coordination.auth_atom_id
+    _pdbx_nonpoly_atom_coordination.PDB_ins_code
+    _pdbx_nonpoly_atom_coordination.number
+    _pdbx_nonpoly_atom_coordination.geometry_calculated
+    _pdbx_nonpoly_atom_coordination.software_remark
+    _pdbx_nonpoly_atom_coordination.provenance
+    _pdbx_nonpoly_atom_coordination.geometry_generic
+    _pdbx_nonpoly_atom_coordination.geometry_abbr
+    _pdbx_nonpoly_atom_coordination.assessment            
+    1 B . SF4 FE1 ? A 86 SF4 FE1 ? 4 tetrahedron regular tetrahedral FindGeo    .    Expected
+    1 B . SF4 FE1 ? A 86 SF4 FE1 ? 4 tetrahedral .       tetrahedral MetalCoord TET  Expected
+    2 B . SF4 FE2 ? A 86 SF4 FE2 ? 4 tetrahedron regular tetrahedral FindGeo    .    Expected
+    2 B . SF4 FE2 ? A 86 SF4 FE2 ? 4 tetrahedral .       tetrahedral MetalCoord TET  Expected
+    3 B . SF4 FE3 ? A 86 SF4 FE3 ? 4 tetrahedron regular tetrahedral FindGeo    .    Expected
+    3 B . SF4 FE3 ? A 86 SF4 FE3 ? 4 tetrahedral .       tetrahedral MetalCoord TET  Expected
+    4 B . SF4 FE4 ? A 86 SF4 FE4 ? 4 tetrahedron regular tetrahedral FindGeo    .    Expected
+    4 B . SF4 FE4 ? A 86 SF4 FE4 ? 4 tetrahedral .       tetrahedral MetalCoord TET  Expected
+;
+  
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.geometry_id
+   _item_description.description  
+;              This data item is used to group together equivalent
+               geometries coming from different software programs.
+	       For instance, if one program has an output of 'tetrahedral'
+               and another has an output of 'tetrahedron' for the same atom,
+	       these two records will have the same geometry_id
+	       because these two outputs represent the same coordination geometry.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.geometry_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.label_asym_id
+   _item_description.description  "              The identifier of the instance of the STRUCT_ASYM_ID to which this feature applies."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.label_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination.label_asym_id"
+   _item_linked.parent_name  "_atom_site.label_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.label_seq_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.label_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.label_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination.label_seq_id"
+   _item_linked.parent_name  "_atom_site.label_seq_id"
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.label_comp_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.label_comp_id in the ATOM_SITE
+               category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.label_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination.label_comp_id"
+   _item_linked.parent_name  "_atom_site.label_comp_id"
+   #
+   _item_type.code  ucode
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.label_atom_id
+   _item_description.description  "              The identifier for the target atom to which the feature is assigned."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.label_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination.label_atom_id"
+   _item_linked.parent_name  "_atom_site.label_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.label_alt_id
+   _item_description.description  "              A place holder to indicate alternate conformation."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.label_alt_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination.label_alt_id"
+   _item_linked.parent_name  "_atom_site.label_alt_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.auth_asym_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_asym_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.auth_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination.auth_asym_id"
+   _item_linked.parent_name  "_atom_site.auth_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.auth_seq_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.auth_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.auth_comp_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_comp_id in
+               the ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.auth_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination.auth_comp_id"
+   _item_linked.parent_name  "_atom_site.auth_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.auth_atom_id
+   _item_description.description  
+;              A component of the identifier for partner 1 of the structure
+               connection.
+
+               This data item is a pointer to _atom_site.auth_atom_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.auth_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination.auth_atom_id"
+   _item_linked.parent_name  "_atom_site.auth_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.PDB_ins_code
+   _item_description.description  "              PDB insertion code."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.PDB_ins_code"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination.PDB_ins_code"
+   _item_linked.parent_name  "_atom_site.pdbx_PDB_ins_code"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.number
+   _item_description.description  "              The coordination number of the target atom."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.number"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   loop_
+   _item_range.maximum
+   _item_range.minimum
+     24  24  
+     24   2  
+      2   2  
+   #
+   loop_
+   _pdbx_item_range.maximum
+   _pdbx_item_range.minimum
+     10  10  
+     10   2  
+      2   2  
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.geometry_calculated
+   _item_description.description  
+;              This data item contains the geometry output from a software program
+               (for example, FindGeo or MetalCoord). The geometry is based on what
+	       is observed in the coordinate file.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.geometry_calculated"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.software_remark
+   _item_description.description  
+;              This data item describes the agreement of the
+               software-generated geometry with the idealized
+               reference geometries. This information is generated by
+               the software that generates geometry annotation.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.software_remark"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  line
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.geometry_generic
+   _item_description.description  
+;              This data item translates the geometry output from a
+               software program (for example, FindGeo or MetalCoord)
+               into a unified naming scheme. As software programs
+               sometimes have different names for the same geometry
+               (for instance, 'tetrahedral' and 'tetrahedron'
+               correspond to the same geometry), this data item
+               provides a name for the geometry that is consistent
+               regardless of the provenance to enhance
+               findability. The geometry is based on what is observed
+               in the coordinate file.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.geometry_generic"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     linear                                        ?  
+     bent                                          ?  
+     "trigonal planar"                             ?  
+     pyramidal                                     ?  
+     "t shape"                                     ?  
+     "linear monocapped"                           ?  
+     tetrahedral                                   ?  
+     "square planar"                               ?  
+     "trigonal pyramidal"                          ?  
+     "trigonal bipyramidal with vacancy"           ?  
+     "square pyramidal with vacancy"               ?  
+     "trigonal planar monocapped"                  ?  
+     "linear bicapped"                             ?  
+     "square non-planar"                           ?  
+     "square pyramidal"                            ?  
+     "trigonal bipyramidal"                        ?  
+     "trigonal prismatic with vacancy"             ?  
+     "square planar monocapped"                    ?  
+     "trigonal planar bicapped"                    ?  
+     "trigonal planar tricapped"                   ?  
+     octahedral                                    ?  
+     "trigonal prismatic"                          ?  
+     "pentagonal bipyramidal with vacancy"         ?  
+     "octahedral monocapped with vacancy"          ?  
+     "trigonal prismatic monocapped with vacancy"  ?  
+     "sandwich 4h 2"                               ?  
+     "sandwich 4 2"                                ?  
+     "sandwich 5 1"                                ?  
+     "square planar bicapped"                      ?  
+     "hexagonal planar"                            ?  
+     "pentagonal bipyramidal"                      ?  
+     "trigonal prismatic monocapped"               ?  
+     "octahedral monocapped"                       ?  
+     "hexagonal bipyramidal with vacancy"          ?  
+     "cubic with vacancy"                          ?  
+     "square antiprismatic with vacancy"           ?  
+     "sandwich 6 1"                                ?  
+     "sandwich 4 3"                                ?  
+     "sandwich 4h 3"                               ?  
+     "sandwich 5 2"                                ?  
+     "hexagonal bipyramidal"                       ?  
+     cubic                                         ?  
+     "square antiprismatic"                        ?  
+     "octahedral bicapped"                         ?  
+     "trigonal prismatic bicapped"                 ?  
+     "sandwich 4h 4h"                              ?  
+     "sandwich 7 1"                                ?  
+     "sandwich 4h 4"                               ?  
+     "sandwich 5 capped 1"                         ?  
+     "sandwich 5 3"                                ?  
+     "sandwich 5h 3"                               ?  
+     "sandwich 6 2"                                ?  
+     dodecahedral                                  ?  
+     "trigonal prism tricapped"                    ?  
+     "square antiprismatic monocapped"             ?  
+     "sandwich 7 2"                                ?  
+     "sandwich 5 tricapped i"                      ?  
+     "sandwich 5 4h"                               ?  
+     "sandwich 5 4"                                ?  
+     "sandwich 6 3"                                ?  
+     "pentagonal prismatic"                        ?  
+     "square antiprismatic bicapped"               ?  
+     "sandwich 5 5o"                               ?  
+     "sandwich 6 trigonal pyramidal"               ?  
+     "sandwich 6 4"                                ?  
+     "sandwich 5 4 i"                              ?  
+     "pentagonal antiprismatic"                    ?  
+     "sandwich 7 3"                                ?  
+     "sandwich 5 tricapped v"                      ?  
+     "sandwich 5 square pyramidal"                 ?  
+     "sandwich 5 5"                                ?  
+     "sandwich 5 pentagonal pyramidal"             ?  
+     "trigonal prismatic all face capped"          ?  
+     "sandwich 5 square pyramidal monocapped"      ?  
+     "sandwich 8 3"                                ?  
+     "sandwich 5 4h v"                             ?  
+     "sandwich 5 5 i"                              ?  
+     "sandwich 6 5"                                ?  
+     seamine                                       ?  
+     cuboctahedral                                 ?  
+     "sandwich 5 hexagonal pyramidal"              ?  
+     "sandwich 8 4"                                ?  
+     "paired octahedral"                           ?  
+     "sandwich 7 5"                                ?  
+     "sandwich 6 6"                                ?  
+     "sandwich 5 5 v"                              ?  
+     "sandwich 6 5 v"                              ?  
+     "sandwich 8 5"                                ?  
+     "sandwich 5 5 v i"                            ?  
+     "sandwich 5 5 v v 3d"                         ?  
+     "sandwich 6 6 v"                              ?  
+     "sandwich c5 5 i"                             ?  
+     "sandwich 5 5 v v"                            ?  
+     "sandwich 8 5 i"                              ?  
+     "sandwich 5 5 4"                              ?  
+     "sandwich 6 6 triangle"                       ?  
+     "sandwich 5 5 star"                           ?  
+     "penta trigonal planar"                       ?  
+     "penta trigonal planar i"                     ?  
+     "sandwich 8 8"                                ?  
+     "penta trigonal planar v"                     ?  
+     "penta trigonal planar i i"                   ?  
+     "sandwich 8 8 i"                              ?  
+     "sandwich 8 8 v"                              ?  
+     ball                                          ?  
+     irregular                                     ?  
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.geometry_abbr
+   _item_description.description  
+;              This data item lists the abbreviated name of the
+               geometry, as specified in the
+               _pdbx_nonpoly_atom_coordination_sphere.descriptor. For
+               instance, square planar is abbreviated to SPL. The
+               geometry derived from observed geometries in atomic
+               coordinate files.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.geometry_abbr"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.provenance
+   _item_description.description  "              The provenance of the feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.provenance"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     PDB         ?  
+     FindGeo     ?  
+     MetalCoord  ?  
+     Author      ?  
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination.assessment
+   _item_description.description  
+;              This data item provides an assessment of the coordination.
+               The assessment is based on comparison with the CCD. If coordination
+	       is annotated in the CCD, then the coordination in the structure will
+	       be compared with the reference(s) in the CCD. If there is a match
+	       with the reference CCD, assessment will be annotated as Expected,
+	       whereas if there is not a match, assessment will be annotated as Unexpected.
+	       If there is no reference in the CCD, assessment will be annotated
+	       as 'No reference'.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination.assessment"
+   _item.category_id     pdbx_nonpoly_atom_coordination
+   _item.mandatory_code  no
+   #
+   _item_type.code  line
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     Expected        ?  
+     Unexpected      ?  
+     "No reference"  ?  
+   #
+save_
+#
+save_pdbx_nonpoly_atom_coordination_sphere
+   _category.description     
+;             Data items in the PDBX_NONPOLY_ATOM_COORDINATION_SPHERE category provide
+              geometric coordination information on selected atoms
+;
+
+   _category.id              pdbx_nonpoly_atom_coordination_sphere
+   _category.mandatory_code  no
+   #
+   loop_
+   _category_key.name
+     "_pdbx_nonpoly_atom_coordination_sphere.id"  
+     "_pdbx_nonpoly_atom_coordination_sphere.label_asym_id"  
+     "_pdbx_nonpoly_atom_coordination_sphere.label_comp_id"  
+     "_pdbx_nonpoly_atom_coordination_sphere.label_atom_id"  
+   #
+   loop_
+   _category_group.id
+     inclusive_group  
+     pdbx_group       
+   #
+   loop_
+   _category_examples.detail
+   _category_examples.case
+     
+;
+    Example 1 - based on 1RPT
+;
+  
+;
+    loop_
+    _pdbx_nonpoly_atom_coordination_sphere.id
+    _pdbx_nonpoly_atom_coordination_sphere.geometry_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_asym_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_seq_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_comp_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_atom_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_alt_id
+    _pdbx_nonpoly_atom_coordination_sphere.auth_asym_id
+    _pdbx_nonpoly_atom_coordination_sphere.auth_seq_id
+    _pdbx_nonpoly_atom_coordination_sphere.auth_comp_id 
+    _pdbx_nonpoly_atom_coordination_sphere.auth_atom_id 
+    _pdbx_nonpoly_atom_coordination_sphere.PDB_ins_code
+    _pdbx_nonpoly_atom_coordination_sphere.descriptor
+    _pdbx_nonpoly_atom_coordination_sphere.provenance
+    1 1 D . VO4 V ? A 343 VO4 V ? @TBP{V,N,O,O,O,O} MetalCoord
+;
+  
+     
+;
+    Example 2 - based on 1HIP
+;
+  
+;
+    loop_
+    _pdbx_nonpoly_atom_coordination_sphere.id
+    _pdbx_nonpoly_atom_coordination_sphere.geometry_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_asym_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_seq_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_comp_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_atom_id
+    _pdbx_nonpoly_atom_coordination_sphere.label_alt_id
+    _pdbx_nonpoly_atom_coordination_sphere.auth_asym_id
+    _pdbx_nonpoly_atom_coordination_sphere.auth_seq_id
+    _pdbx_nonpoly_atom_coordination_sphere.auth_comp_id 
+    _pdbx_nonpoly_atom_coordination_sphere.auth_atom_id 
+    _pdbx_nonpoly_atom_coordination_sphere.PDB_ins_code 
+    _pdbx_nonpoly_atom_coordination_sphere.descriptor
+    _pdbx_nonpoly_atom_coordination_sphere.provenance
+    1 1 B . SF4 FE1 ? A 86 SF4 FE1 ? @TET{Fe,S,S,S,S} MetalCoord
+    2 2 B . SF4 FE1 ? A 86 SF4 FE1 ? @TET{Fe,S,S,S,S} MetalCoord
+    3 3 B . SF4 FE1 ? A 86 SF4 FE1 ? @TET{Fe,S,S,S,S} MetalCoord
+    4 4 B . SF4 FE1 ? A 86 SF4 FE1 ? @TET{Fe,S,S,S,S} MetalCoord
+;
+  
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.id
+   _item_description.description  
+;    This data item is the parent for
+     _pdbx_nonpoly_atom_coordination_sphere_order.sphere_id.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.geometry_id
+   _item_description.description  
+;    This data item is a foreign key to _pdbx_nonpoly_atom_coordination.geometry_id. This
+     item maps the coordination descriptor to a specific geometry described in the
+     pdbx_nonpoly_atom_coordination category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.geometry_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.geometry_id"
+   _item_linked.parent_name  "_pdbx_nonpoly_atom_coordination.geometry_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.label_asym_id
+   _item_description.description  "              The identifier of the instance of the STRUCT_ASYM_ID to which this feature applies."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.label_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.label_asym_id"
+   _item_linked.parent_name  "_atom_site.label_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.label_seq_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.label_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.label_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  no
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.label_seq_id"
+   _item_linked.parent_name  "_atom_site.label_seq_id"
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.label_comp_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.comp_id in the ATOM_SITE
+               category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.label_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.label_comp_id"
+   _item_linked.parent_name  "_atom_site.label_comp_id"
+   #
+   _item_type.code  ucode
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.label_atom_id
+   _item_description.description  "              The identifier for the target atom to which the feature is assigned."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.label_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.label_atom_id"
+   _item_linked.parent_name  "_atom_site.label_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.label_alt_id
+   _item_description.description  "              A place holder to indicate alternate conformation."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.label_alt_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.label_alt_id"
+   _item_linked.parent_name  "_atom_site.label_alt_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.auth_asym_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_asym_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.auth_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.auth_asym_id"
+   _item_linked.parent_name  "_atom_site.auth_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.auth_seq_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.auth_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.auth_seq_id"
+   _item_linked.parent_name  "_atom_site.auth_seq_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.auth_comp_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_comp_id in
+               the ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.auth_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.auth_comp_id"
+   _item_linked.parent_name  "_atom_site.auth_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.auth_atom_id
+   _item_description.description  
+;              A component of the identifier for partner 1 of the structure
+               connection.
+
+               This data item is a pointer to _atom_site.auth_atom_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.auth_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  no
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.auth_atom_id"
+   _item_linked.parent_name  "_atom_site.auth_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.PDB_ins_code
+   _item_description.description  "              PDB insertion code."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.PDB_ins_code"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere.PDB_ins_code"
+   _item_linked.parent_name  "_atom_site.pdbx_PDB_ins_code"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.descriptor
+   _item_description.description  
+;              This data item contains a descriptor of the coordination environment
+               of an atom. The descriptor is based on what is observed in the coordinate
+	       file.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.descriptor"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere.provenance
+   _item_description.description  "              The provenance of the feature assigned to this atom."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere.provenance"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere
+   _item.mandatory_code  yes
+   #
+   _item_type.code  ucode
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     PDB         ?  
+     FindGeo     ?  
+     MetalCoord  ?  
+   #
+save_
+#
+save_pdbx_nonpoly_atom_coordination_sphere_order
+   _category.description     
+;              This category describes the order of the atoms in the
+               coordination sphere category:
+               pdbx_nonpoly_atom_coordination_sphere. The order of the
+               atoms is the encoding of the 3D arrangement of atoms
+               for a particular coordination geometry.
+;
+
+   _category.id              pdbx_nonpoly_atom_coordination_sphere_order
+   _category.mandatory_code  no
+   #
+   loop_
+   _category_key.name
+     "_pdbx_nonpoly_atom_coordination_sphere_order.sphere_id"  
+     "_pdbx_nonpoly_atom_coordination_sphere_order.label_comp_id"  
+     "_pdbx_nonpoly_atom_coordination_sphere_order.label_atom_id"  
+     "_pdbx_nonpoly_atom_coordination_sphere_order.atom_place"  
+   #
+   loop_
+   _category_group.id
+     inclusive_group  
+     pdbx_group       
+   #
+   loop_
+   _category_examples.detail
+   _category_examples.case
+     
+;
+    Example 1 - based on 1RPT
+;
+  
+;
+    loop_
+    _pdbx_nonpoly_atom_coordination_sphere_order.sphere_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_asym_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_seq_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_comp_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_atom_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_alt_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.auth_asym_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.auth_seq_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.auth_comp_id 
+    _pdbx_nonpoly_atom_coordination_sphere_order.auth_atom_id 
+    _pdbx_nonpoly_atom_coordination_sphere_order.PDB_ins_code
+    _pdbx_nonpoly_atom_coordination_sphere_order.symmetry_operation
+    _pdbx_nonpoly_atom_coordination_sphere_order.atom_place 
+    1 A 12 HIS NE2 ? A 12  HIS NE2 ? x,y,z 1
+    1 D .  VO4 O1  ? A 343 VO4 O1  ? x,y,z 2
+    1 D .  VO4 O2  ? A 343 VO4 O2  ? x,y,z 3
+    1 D .  VO4 O3  ? A 343 VO4 O3  ? x,y,z 4
+    1 D .  VO4 O4  ? A 343 VO4 O4  ? x,y,z 5
+;
+  
+     
+;
+    Example 2 - based on 1HIP
+;
+  
+;
+    loop_
+    _pdbx_nonpoly_atom_coordination_sphere_order.sphere_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_asym_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_seq_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_comp_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_atom_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.label_alt_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.auth_asym_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.auth_seq_id
+    _pdbx_nonpoly_atom_coordination_sphere_order.auth_comp_id 
+    _pdbx_nonpoly_atom_coordination_sphere_order.auth_atom_id 
+    _pdbx_nonpoly_atom_coordination_sphere_order.PDB_ins_code
+    _pdbx_nonpoly_atom_coordination_sphere_order.symmetry_operation
+    _pdbx_nonpoly_atom_coordination_sphere_order.atom_place 
+    1 B .  SF4 FE1 ? A 86 SF4 FE1 ? x,y,z 1
+    1 B .  SF4 FE1 ? A 86 SF4 FE1 ? x,y,z 2
+    1 B .  SF4 FE1 ? A 86 SF4 FE1 ? x,y,z 3
+    1 A 43 CYS SG  ? A 43 CYS SG  ? x,y,z 4
+    2 B .  SF4 FE2 ? A 86 SF4 FE2 ? x,y,z 1
+    2 B .  SF4 FE2 ? A 86 SF4 FE2 ? x,y,z 2
+    2 B .  SF4 FE2 ? A 86 SF4 FE2 ? x,y,z 3
+    2 A 46 CYS SG  ? A 46 CYS SG  ? x,y,z 4
+    3 B .  SF4 FE3 ? A 86 SF4 FE3 ? x,y,z 1
+    3 B .  SF4 FE3 ? A 86 SF4 FE3 ? x,y,z 2
+    3 B .  SF4 FE3 ? A 86 SF4 FE3 ? x,y,z 3
+    3 A 63 CYS SG  ? A 63 CYS SG  ? x,y,z 4
+    4 B .  SF4 FE4 ? A 86 SF4 FE4 ? x,y,z 1
+    4 B .  SF4 FE4 ? A 86 SF4 FE4 ? x,y,z 2
+    4 B .  SF4 FE4 ? A 86 SF4 FE4 ? x,y,z 3
+    4 A 77 CYS SG  ? A 77 CYS SG  ? x,y,z 4
+;
+  
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.sphere_id
+   _item_description.description  
+;              This data item is a foreign key to
+               _pdbx_nonpoly_atom_coordination_sphere.id
+               This item maps the coordination sphere order to a
+               specific coordination sphere described in the
+               pdbx_nonpoly_atom_coordination_sphere category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.sphere_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere_order.sphere_id"
+   _item_linked.parent_name  "_pdbx_nonpoly_atom_coordination_sphere.id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.label_asym_id
+   _item_description.description  "              The identifier of the instance of the STRUCT_ASYM_ID to which this feature applies."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.label_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  yes
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere_order.label_asym_id"
+   _item_linked.parent_name  "_atom_site.label_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.label_seq_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.label_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.label_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  no
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere_order.label_seq_id"
+   _item_linked.parent_name  "_atom_site.label_seq_id"
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.label_comp_id
+   _item_description.description  
+;              This data item is a pointer to _atom_site.comp_id in the ATOM_SITE
+               category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.label_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  yes
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere_order.label_comp_id"
+   _item_linked.parent_name  "_atom_site.label_comp_id"
+   #
+   _item_type.code  ucode
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.label_atom_id
+   _item_description.description  "              The identifier for the target atom to which the feature is assigned."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.label_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  yes
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere_order.label_atom_id"
+   _item_linked.parent_name  "_atom_site.label_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.label_alt_id
+   _item_description.description  "              A place holder to indicate alternate conformation."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.label_alt_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.auth_asym_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_asym_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.auth_asym_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere_order.auth_asym_id"
+   _item_linked.parent_name  "_atom_site.auth_asym_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.auth_seq_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_seq_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.auth_seq_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.auth_comp_id
+   _item_description.description  
+;              A component of the identifier for the residue at which the
+               conformation segment begins.
+
+               This data item is a pointer to _atom_site.auth_comp_id in
+               the ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.auth_comp_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere_order.auth_comp_id"
+   _item_linked.parent_name  "_atom_site.auth_comp_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.auth_atom_id
+   _item_description.description  
+;              A component of the identifier for partner 1 of the structure
+               connection.
+
+               This data item is a pointer to _atom_site.auth_atom_id in the
+               ATOM_SITE category.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.auth_atom_id"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  no
+   #
+   _item_type.code  atcode
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere_order.auth_atom_id"
+   _item_linked.parent_name  "_atom_site.auth_atom_id"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.PDB_ins_code
+   _item_description.description  "              PDB insertion code."
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.PDB_ins_code"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_nonpoly_atom_coordination_sphere_order.PDB_ins_code"
+   _item_linked.parent_name  "_atom_site.pdbx_PDB_ins_code"
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.atom_place
+   _item_description.description  
+;              This data item enumerates the order of the atom in the
+               coordination sphere, which is the encoding of the 3D
+               arrangement of the atoms.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.atom_place"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  yes
+   #
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_nonpoly_atom_coordination_sphere_order.symmetry_operation
+   _item_description.description  
+;              The symmetry operator to apply to the specific atom to
+               move it into the coordinate spehere.
+;
+
+   #
+   _item.name            "_pdbx_nonpoly_atom_coordination_sphere_order.symmetry_operation"
+   _item.category_id     pdbx_nonpoly_atom_coordination_sphere_order
+   _item.mandatory_code  yes
+   #
+   _item_type.code  line
+   #
+save_
+#
+save__chem_comp_bond.pdbx_metal_pi_flag
+   _item_description.description  "              This data item identifies if this is a bond between a metal and a pi system (alkene, arene, etc)."
+   #
+   _item.name            "_chem_comp_bond.pdbx_metal_pi_flag"
+   _item.category_id     chem_comp_bond
+   _item.mandatory_code  no
+   #
+   _item_type.code  ucode
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     Y  .  
+     N  .  
+   #
+save_
+#
+save__chem_comp_bond.pdbx_metal_coordination_flag
+   _item_description.description  
+;              This data item identifies if this is a bond between a metal and its coordinating group, otherwise
+               referred to as a dative or coordinate covalent bond. This flag is used for all bonds between
+	       metals and non-metals, including metal-pi bonds and all other metal coordination bonds.
+;
+
+   #
+   _item.name            "_chem_comp_bond.pdbx_metal_coordination_flag"
+   _item.category_id     chem_comp_bond
+   _item.mandatory_code  no
+   #
+   _item_type.code  ucode
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     Y  .  
+     N  .  
+   #
+save_
+#
+save__pdbx_depui_status_flags.metal_experiment_evidence
+   _item_description.description  
+;   This data item will be set to Y if the author provides experimental support for metal features in the DepUI. This
+    data item will be set to N if the author does not provide experimental support for metal features in the DepUI.
+;
+
+   #
+   _item.name            "_pdbx_depui_status_flags.metal_experiment_evidence"
+   _item.category_id     pdbx_depui_status_flags
+   _item.mandatory_code  no
+   #
+   _item_type.code  code
+   #
+   loop_
+   _item_enumeration.value
+     Y  
+     N  
    #
 save_
 #


### PR DESCRIPTION
Automated update of the bundled PDBx/mmCIF dictionary.

**Dictionary version:** `5.413`
**Source:** https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_pdbx_v50.dic

This PR was created automatically by the `update-dictionary` workflow.
Please review, run the test suite, and merge when ready.